### PR TITLE
Voigt spain hotfix

### DIFF
--- a/common/ai_strategy/IHMP_SPR.txt
+++ b/common/ai_strategy/IHMP_SPR.txt
@@ -14,13 +14,10 @@
 # building_target
 
 
-POR_MP_Early_Production = {
+SPR_MP_Anti_Guerilla_Production = {
 
 	enable = {
-		OR = {
-			tag = SPR
-			tag = SPA
-		}
+		original_tag = SPR
 		has_game_rule = {
 			rule = SPR_ai_behavior 
 			option = SPR_MP_1
@@ -50,32 +47,45 @@ POR_MP_Early_Production = {
 			NOT = { 793 = { is_core_of = ROOT } }
 			NOT = { 794 = { is_core_of = ROOT }	}
 		}
+		has_equipment = {
+			infantry_equipment_1 < 2000
+		}
+		has_equipment = {
+			infantry_equipment_2 < 2000
+		}
 	}
 	abort = {
-		AND = {
-			41 = { is_core_of = ROOT }
-			165 = { is_core_of = ROOT }
-			166 = { is_core_of = ROOT }
-			167 = { is_core_of = ROOT }
-			168 = { is_core_of = ROOT }
-			169 = { is_core_of = ROOT }
-			170 = { is_core_of = ROOT }
-			171 = { is_core_of = ROOT }
-			172 = { is_core_of = ROOT }
-			173 = { is_core_of = ROOT }
-			174 = { is_core_of = ROOT }
-			175 = { is_core_of = ROOT }
-			176 = { is_core_of = ROOT }
-			#177 = { is_core_of = ROOT }
-			178 = { is_core_of = ROOT }
-			788 = { is_core_of = ROOT }
-			789 = { is_core_of = ROOT }
-			790 = { is_core_of = ROOT }
-			791 = { is_core_of = ROOT }
-			792 = { is_core_of = ROOT }
-			793 = { is_core_of = ROOT }
-			794 = { is_core_of = ROOT }
-		
+		OR = {
+			AND = {
+				41 = { is_core_of = ROOT }
+				165 = { is_core_of = ROOT }
+				166 = { is_core_of = ROOT }
+				167 = { is_core_of = ROOT }
+				168 = { is_core_of = ROOT }
+				169 = { is_core_of = ROOT }
+				170 = { is_core_of = ROOT }
+				171 = { is_core_of = ROOT }
+				172 = { is_core_of = ROOT }
+				173 = { is_core_of = ROOT }
+				174 = { is_core_of = ROOT }
+				175 = { is_core_of = ROOT }
+				176 = { is_core_of = ROOT }
+				#177 = { is_core_of = ROOT }
+				178 = { is_core_of = ROOT }
+				788 = { is_core_of = ROOT }
+				789 = { is_core_of = ROOT }
+				790 = { is_core_of = ROOT }
+				791 = { is_core_of = ROOT }
+				792 = { is_core_of = ROOT }
+				793 = { is_core_of = ROOT }
+				794 = { is_core_of = ROOT }
+			}
+			has_equipment = {
+				infantry_equipment_1 > 6000
+			}
+			has_equipment = {
+				infantry_equipment_2 > 6000
+			}
 		}
 	}
 
@@ -98,5 +108,14 @@ POR_MP_Early_Production = {
 		type = equipment_variant_production_factor
 		id = anti_tank_equipment
 		value = -1000
+	}
+	ai_strategy = {
+		type = equipment_variant_production_factor
+		id = motorized_equipment
+		value = -1000
+	}
+	ai_strategy = {
+		type = template_xp_reserve
+		value = 100
 	}
 }

--- a/common/ai_strategy_plans/SPD_MP_plan.txt
+++ b/common/ai_strategy_plans/SPD_MP_plan.txt
@@ -47,20 +47,29 @@ SPD_MP_1 = {
 		SPR_oppose_the_communists
 		SPR_fortify_the_central_government
 		SPR_secure_democratic_principles
+		#PostSCW
 		SPR_stabilize_the_nation
-		SPR_restore_higher_education
 		SPR_provide_for_the_people
 		SPR_collectivize_industry
 		SPR_connect_the_country
 		SPR_transplant_soviet_industry
 		SPR_the_five_year_plan
 		SPR_slipway_enlargement
+		SPR_subvert_soviet_control
+		SPR_war_of_independence
+		SPR_restore_higher_education
 		SPR_engineering_advances
 		SPR_rebuild_the_nation
 		SPR_reprofessionalize_the_military
 		SPR_revive_the_republican_navy
-		SPR_subvert_soviet_control
-		SPR_war_of_independence
+	}
+
+	research = {
+		air_equipment = -1000
+		synth_resources = -1000
+		concentrated_industry_category = 50
+		industry = -100
+		armor = -1000
 	}
 
 	ideas = {
@@ -74,7 +83,8 @@ SPD_MP_1 = {
 		closed_economy = 0
 		disarmed_nation = 0
 		volunteer_only = 0
-		limited_conscription = 0
+		limited_conscription = 100
+		extensive_conscription = 200
 		SPR_juan_negrin = 4
 		SPR_francisco_largo_caballero = 50
 		SPR_augusto_barcia_trelles_vanilla = 0
@@ -90,6 +100,28 @@ SPD_MP_1 = {
 		modifier = {
 			factor = 1.0
 		}
+	}
+}
+
+SPD_MP_Get_PP = {
+	name = "Spain get PP in SCW"
+	desc = ""
+
+	enable = {
+		tag = SPD
+		has_game_rule = {
+			rule = SPR_ai_behavior 
+			option = SPR_MP_1
+		}
+	}
+	abort = {
+		has_global_flag = scw_over
+	}
+
+	focus_factors = {
+		SPR_petition_for_french_aid = 0
+		SPR_soviet_military_advisors = 0
+		SPR_soviet_technological_advancements = 0
 	}
 }
 
@@ -138,9 +170,9 @@ SPD_MP_No_Naval_Missions = {
 
 }
 
-SPD_MP_No_Anarchist = {
-	name = "Spanish No Anarchist"
-	desc = "Don't provoke anarchist revolution early"
+SPD_German_Border = {
+	name = "Guard the German border after France has fallen"
+	desc = ""
 
 	enable = {
 		tag = SPD
@@ -148,48 +180,74 @@ SPD_MP_No_Anarchist = {
 			rule = SPR_ai_behavior 
 			option = SPR_MP_1
 		}
-		SPD = {
-			check_variable = {
-				var = days_mission_timeout@SPR_anarchist_uprising_mission
-				value = 40
-				compare = greater_than
-			}
-		}
-		any_country_with_original_tag = {
-			original_tag_to_check = SPR
-			tag = SPA
-			AND = {
-				NOT = { surrender_progress > 0.9 }
-				has_capitulated = no
-
-			}
-		}
-	}
-	abort = {
-		SPD = {
-			check_variable = {
-				var = days_mission_timeout@SPR_anarchist_uprising_mission
-				value = 40
-				compare = less_than_or_equals
-			}
-		}
-		any_country_with_original_tag = {
-			original_tag_to_check = SPR
-			tag = SPA
-			OR = {
-				surrender_progress > 0.9
-				has_capitulated = yes
-			}
-		}
+		has_global_flag = scw_over
+		GER = { controls_state = 806 }
+		SOV = { NOT = { has_country_flag = SOV_annexed_spanish_land } }
 	}
 
-	#focus_factors = {
-	#	SPR_crush_the_revolution = 0
-	#}
+	abort_when_not_enabled = yes
+
+	ai_strategy = {
+		type = front_unit_request
+		tag = GER
+		value = 800
+	}
+	ai_strategy = {
+		type = garrison
+		value = -100
+	}
 }
 
-SPD_MP_Wait = {
-	name = "Spanish Democratic MP waiting plan"
+SPD_Vichy_Border = {
+	name = "Do not guard the Vichy border"
+	desc = ""
+
+	enable = {
+		tag = SPD
+		has_game_rule = {
+			rule = SPR_ai_behavior 
+			option = SPR_MP_1
+		}
+		has_global_flag = scw_over
+		has_global_flag = vichy_yes
+		NOT = { GER = { controls_state = 31 } }
+	}
+
+	abort_when_not_enabled = yes
+
+	ai_strategy = {
+		type = front_unit_request
+		state = 31
+		state = 462
+		state = 557
+		value = -200
+	}
+}
+
+SPD_Wait_Revolt = {
+	name = "Spain wait with revolt"
+	desc = ""
+
+	enable = {
+		tag = SPD
+		has_game_rule = {
+			rule = SPR_ai_behavior 
+			option = SPR_MP_1
+		}
+		date < 1941.1.1
+		SOV = { NOT = { has_war_with = GER } }
+		SOV = { NOT = { has_war_with = JAP } }
+	}
+
+	abort_when_not_enabled = yes
+
+	focus_factors = {
+		SPR_subvert_soviet_control = 0
+	}
+}
+
+SPD_Wait_Independence = {
+	name = "Spain wait focus path"
 	desc = "Wait till Soviet picks event option"
 
 	enable = {
@@ -200,6 +258,7 @@ SPD_MP_Wait = {
 		}
 		has_completed_focus = SPR_war_of_independence
 	}
+
 	abort = {
 		OR = {
 			focus_progress = {
@@ -236,9 +295,9 @@ SPD_MP_Wait = {
 	}
 }
 
-SPD_MP_2 = {
-	name = "Spanish Democratic MP plan"
-	desc = "Peaceful Independence"
+SPD_Peaceful_Independence = {
+	name = "Peaceful Independence"
+	desc = ""
 
 	enable = {
 		tag = SPD
@@ -251,15 +310,18 @@ SPD_MP_2 = {
 		is_subject = no
 		SOV = { NOT = { has_country_flag = SOV_annexed_spanish_land } }
 	}
-	abort = {
-		
-	}
+
+	abort_when_not_enabled = yes
 
 	ai_national_focuses = {
 		SPR_war_of_independence
 		SPR_those_who_would_not_help_us
 		SPR_foreign_industrial_aid
 		SPR_ideological_allies
+	}
+
+	focus_factors = {
+		SPR_enemies_of_our_enemy = 0
 	}
 
 	ideas = {
@@ -273,27 +335,18 @@ SPD_MP_2 = {
 		closed_economy = 0
 		disarmed_nation = 0
 		volunteer_only = 0
-		limited_conscription = 0
+		limited_conscription = 1
+		extensive_conscription = 20
 		SPR_juan_negrin = 3
 		SPR_francisco_largo_caballero = 2
 		SPR_augusto_barcia_trelles_vanilla = 0
 		SPR_diego_martinez_barrio_vanilla = 0
 	}
-
-	# Keep small, as it is used as a factor for some things (such as research needs)
-	# Recommended around 1.0. Useful for relation between plans
-	weight = {
-		factor = 1.0
-		modifier = {
-			factor = 1.0
-		}
-	}
-
 }
 
-SPD_MP_2 = {
-	name = "Spanish Democratic MP plan"
-	desc = "War with Soviet Union"
+SPD_War_With_SOV = {
+	name = "War with Soviet Union"
+	desc = ""
 
 	enable = {
 		tag = SPD
@@ -304,15 +357,18 @@ SPD_MP_2 = {
 		has_completed_focus = SPR_war_of_independence
 		has_war_with = SOV
 	}
-	abort = {
-		
-	}
+
+	abort_when_not_enabled = yes
 
 	ai_national_focuses = {
 		SPR_war_of_independence
 		SPR_enemies_of_our_enemy
 		SPR_deal_with_the_devil
 		SPR_foreign_industrial_aid
+	}
+
+	focus_factors = {
+		SPR_those_who_would_not_help_us = 0
 	}
 
 	ideas = {
@@ -326,42 +382,11 @@ SPD_MP_2 = {
 		closed_economy = 0
 		disarmed_nation = 0
 		volunteer_only = 0
-		limited_conscription = 0
+		limited_conscription = 1
+		extensive_conscription = 20
 		SPR_juan_negrin = 3
 		SPR_francisco_largo_caballero = 2
 		SPR_augusto_barcia_trelles_vanilla = 0
 		SPR_diego_martinez_barrio_vanilla = 0
-	}
-
-	# Keep small, as it is used as a factor for some things (such as research needs)
-	# Recommended around 1.0. Useful for relation between plans
-	weight = {
-		factor = 1.0
-		modifier = {
-			factor = 1.0
-		}
-	}
-
-}
-
-SPD_MP_Get_PP = {
-	name = "Spanish Democratic MP plan"
-	desc = "Multiplayer behavior for Democratic Spain"
-
-	enable = {
-		tag = SPD
-		has_game_rule = {
-			rule = SPR_ai_behavior 
-			option = SPR_MP_1
-		}
-	}
-	abort = {
-		has_global_flag = scw_over
-	}
-
-	focus_factors = {
-		SPR_petition_for_french_aid = 0
-		SPR_soviet_military_advisors = 0
-		SPR_soviet_technological_advancements = 0
 	}
 }

--- a/common/ai_strategy_plans/SPR_MP_plan.txt
+++ b/common/ai_strategy_plans/SPR_MP_plan.txt
@@ -233,12 +233,8 @@ SPR_MP_After_SCW = {
 		OR = {
 			tag = SPD
 			tag = SPC
-			OR = {
-				has_war_with = ENG
-				has_war_with = GER
-			}
-		}
-		OR = {
+			has_war_with = ENG
+			has_war_with = GER
 			AND = {
 				GER = { has_completed_focus = GER_nationalist_spain_ally }
 				ENG = { has_completed_focus = uk_spain_focus }
@@ -262,7 +258,6 @@ SPR_MP_After_SCW = {
 				ENG = { has_completed_focus = uk_spain_focus }
 			}
 		}
-		
 	}
 
 	ai_national_focuses = {
@@ -326,7 +321,7 @@ SPR_MP_After_SCW = {
 	}
 }
 
-SPR_MP_plan_war_with_allies = {
+SPR_MP_war_with_allies = {
 	name = "Spanish anti-Allied plan"
 	desc = "Multiplayer behavior for Nationalist Spain at war with the Allies"
 
@@ -427,7 +422,7 @@ SPR_MP_plan_war_with_allies = {
 
 }
 
-SPR_historical_plan_war_with_axis = {
+SPR_MP_war_with_axis = {
 	name = "Spanish anti-Axis plan"
 	desc = "Multiplayer behavior for Nationalist Spain at war with the Axis"
 
@@ -663,10 +658,10 @@ SPR_MP_Neutrality = {
 
 SPR_MP_1_No_Iberian_Pact_Ever = {
 	name = "No Iberian Pact"
-	desc = "Never pick Iberian Pact or Restoer Monarchy"
+	desc = "Never pick Iberian Pact or Restore Monarchy"
 
 	enable = {
-		tag = SPR
+		tag = SPA
 		has_game_rule = {
 			rule = SPR_ai_behavior
 			option = SPR_MP_1
@@ -684,7 +679,7 @@ SPR_MP_1_Trade_Peace = {
 	desc = "Don't switch Tradelaws"
 
 	enable = {
-		tag = SPR
+		tag = SPA
 		has_game_rule = {
 			rule = SPR_ai_behavior
 			option = SPR_MP_1
@@ -705,7 +700,7 @@ SPR_MP_1_Trade_Axis = {
 	desc = "Switch to Export Focus for Axis Tungsten"
 
 	enable = {
-		tag = SPR
+		tag = SPA
 		has_game_rule = {
 			rule = SPR_ai_behavior
 			option = SPR_MP_1
@@ -726,7 +721,7 @@ SPR_MP_1_Theorist = {
 	desc = ""
 
 	enable = {
-		tag = SPR
+		tag = SPA
 		has_game_rule = {
 			rule = SPR_ai_behavior
 			option = SPR_MP_1
@@ -745,7 +740,7 @@ SPR_MP_1_Carlist_Theorist = {
 	desc = ""
 
 	enable = {
-		tag = SPR
+		tag = SPA
 		has_game_rule = {
 			rule = SPR_ai_behavior
 			option = SPR_MP_1
@@ -794,8 +789,8 @@ MP_1_No_AirUnits = {
 			option = SPR_MP_1
 		}
 	}
-	abort = {
-	}
+	
+	abort_when_not_enabled = yes
 
 	research = {
 		air_equipment = -1000


### PR DESCRIPTION
[F] Made sure certain ai_strategies are only active for Nationalist Spain, preventing various bugs
[F] Made sure multiple ai_strategy_plans don't have the same name, so their effects don't overwrite each other
[F] Made the Spains also save up ArmyXP for fighting the guerrillas to core back their territory.

[A] Republican Spain now should consistently increase their manpower law
[A] Republican Spain now should have better industry research (slightly less ahead of time, but also doing concentrated industry more)
[A] Made Republican Spain start their revolt after 1941 begins (takes 140 days to complete both foci)
[A] Independent Republican Spain now should put its divisions against the German border, and not against the Vichy border.