### PR TITLE
Some small fixes for Portugal for the ongoing game

### DIFF
--- a/common/ai_strategy_plans/POR_MP_plan.txt
+++ b/common/ai_strategy_plans/POR_MP_plan.txt
@@ -27,6 +27,8 @@ POR_historical_plan = {
 		POR_concordat_with_the_holy_see
 		POR_national_gold_reserves
 		POR_proudly_alone
+		POR_honor_anglo_portuguese_alliance
+		POR_research_sharing
 		POR_ogme
 		POR_portuguese_artillery
 		POR_military_research_facilities
@@ -66,9 +68,15 @@ POR_historical_plan = {
 		POR_the_eastern_menace = 0
 		POR_the_communist_threat = 0
 		POR_national_syndicalism = 0
-		POR_honor_anglo_portuguese_alliance = 0
 		POR_a_royal_wedding = 0
-	}				
+	}
+
+	research = {
+		synth_resources = -1000
+		concentrated_industry_category = 45
+		industry = -50
+		armor = -1000
+	}
 
 	ai_strategy = {
 	 	type = front_unit_request
@@ -92,6 +100,28 @@ POR_historical_plan = {
 		}
 	}
 
+}
+
+POR_No_Allies = {
+	name = "Don't join Allies willingly"
+	desc = ""
+
+	enable = {
+		tag = POR
+		has_game_rule = {
+			rule = POR_ai_behavior
+			option = POR_MP_1
+		}
+		NOT= { is_in_faction_with = ENG }
+	}
+
+	abort = {
+		is_in_faction_with = ENG
+	}
+	
+	focus_factors = {
+		POR_honor_anglo_portuguese_alliance = 0
+	}
 }
 
 POR_MP_Ideas = {
@@ -169,10 +199,14 @@ POR_MP_Garrision = {
 	 	type = front_unit_request
 		tag = SPR
 		value = -200
-	}	
+	}
+	ai_strategy = {
+		type = garrison
+		value = -100
+	}
 	ai_strategy = {
 		type = put_unit_buffers
-		ratio = 1.0
+		ratio = 5.0
 		states = { 
 			112
 			179
@@ -493,7 +527,10 @@ MP_Spy_Defense_0 = {
 			rule = POR_ai_behavior
 			option = POR_MP_1
 		}
-		has_completed_focus = POR_proudly_alone
+		OR = {
+			has_completed_focus = POR_proudly_alone
+			has_completed_focus = POR_honor_anglo_portuguese_alliance
+		}
 		has_capitulated = no
 		date < 1942.1.1
 	}
@@ -743,6 +780,6 @@ MP_Economy_2 = {
 	ideas = {
 		civilian_economy = 0
 		low_economic_mobilisation = 0
-		partial_economic_mobilisation = 0
+		partial_economic_mobilisation = -1000
 	}
 }

--- a/common/national_focus/portugal.txt
+++ b/common/national_focus/portugal.txt
@@ -1,0 +1,6649 @@
+### search_filters = {FOCUS_FILTER_POLITICAL}
+### search_filters = {FOCUS_FILTER_RESEARCH}
+### search_filters = {FOCUS_FILTER_INDUSTRY}
+### search_filters = {FOCUS_FILTER_STABILITY}
+### search_filters = {FOCUS_FILTER_WAR_SUPPORT}
+### search_filters = {FOCUS_FILTER_MANPOWER}
+### search_filters = {FOCUS_FILTER_ANNEXATION}
+
+focus_tree = {
+	id = portuguese_focus
+	
+	country = {
+		factor = 0
+		
+		modifier = {
+			add = 10
+			tag = POR
+			has_dlc = "La Resistance"
+		}
+	}
+	
+	default = no
+
+	continuous_focus_position = { x = 50 y = 1500 }
+
+	focus = {
+		id = POR_colonial_assimilation_policy
+		available = {
+			any_owned_state = {
+				NOT = { is_core_of = ROOT }
+			}
+		}
+
+		bypass = {
+		}
+
+		icon = GFX_focus_generic_military_academy
+		x = 2
+		y = 0
+
+		cost = 10
+		search_filters = {FOCUS_FILTER_MANPOWER}
+		completion_reward = {
+			add_ideas = POR_colonial_assimilation_policy
+		}
+	}
+	
+	focus = {
+		id = POR_colonial_army
+		available = {
+			any_owned_state = {
+				NOT = { is_core_of = ROOT }
+			}
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_colonial_assimilation_policy }
+
+		icon = GFX_focus_generic_little_entente
+		x = 0
+		y = 1
+
+		relative_position_id = POR_colonial_assimilation_policy
+		cost = 10
+		search_filters = {FOCUS_FILTER_MANPOWER}
+		completion_reward = {
+			add_ideas = POR_colonial_army
+			custom_effect_tooltip = available_political_advisor
+			show_ideas_tooltip = POR_francisco_craveiro_lopes
+		}
+	}
+
+	focus = {
+		id = POR_luso_tropicalism
+		available = {
+			NOT = { has_government = fascism }
+			OR = {
+				has_full_control_of_state = 796 #North Angola
+				has_full_control_of_state = 540 #South Angola
+				has_full_control_of_state = 544 #Mozambique
+			}
+		}
+
+		ai_will_do = {
+			factor = 1
+			modifier = {
+				add = 1
+				OR = {
+					has_government = neutrality
+					has_government = fascism
+					has_government = communism
+				}
+			}
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_colonial_assimilation_policy }
+		mutually_exclusive = { focus = POR_limited_self_rule }
+			
+		icon = GFX_focus_por_luso_tropicalism
+		x = -2
+		y = 2
+
+		relative_position_id = POR_colonial_assimilation_policy
+		cost = 10
+		search_filters = {FOCUS_FILTER_ANNEXATION}
+		completion_reward = {
+			unlock_decision_tooltip = POR_mozambique_overseas_territory
+			unlock_decision_tooltip = POR_angola_overseas_province
+		}
+	}
+
+	focus = {
+		id = POR_limited_self_rule
+		available = {
+			OR = {
+				has_full_control_of_state = 796 #North Angola
+				has_full_control_of_state = 540 #South Angola
+				has_full_control_of_state = 544 #Mozambique
+			}
+		}
+
+		ai_will_do = {
+			factor = 1
+			modifier = {
+				factor = 0
+				OR = {
+					has_government = fascism
+					has_government = neutrality
+				}			
+			}
+			modifier = {
+				add = 1
+				OR = {
+					has_government = democratic
+					any_country = {
+						is_in_faction_with = ROOT
+						is_faction_leader = yes
+						has_government = democratic
+					}
+				}		
+			}
+		}
+
+		bypass = {
+		}
+		prerequisite = { focus = POR_colonial_army }
+		mutually_exclusive = { focus = POR_luso_tropicalism }
+			
+		icon = GFX_focus_por_limited_self_rule
+
+		x = 0
+		y = 1
+
+		relative_position_id = POR_colonial_army
+		cost = 10
+		completion_reward = {
+			add_political_power = 120
+			add_manpower = 30000
+			ANG = {
+				if = {
+					limit = { 
+						POR = { has_full_control_of_state = 796 }
+					}
+					transfer_state = 796
+					POR = { set_country_flag = POR_released_angola_flag }
+				}
+				if = {
+					limit = { 
+						POR = { has_full_control_of_state = 540 }
+					}
+					transfer_state = 540
+					POR = { set_country_flag = POR_released_angola_flag }
+				}								
+			}
+
+			MZB = {
+				if = {
+					limit = { 
+						POR = { has_full_control_of_state = 544 }
+					}
+					transfer_state = 544
+					POR = { set_country_flag = POR_released_mozambique_flag }
+				}	
+			}
+
+			if = {
+				limit = {
+					OR = {
+						has_dlc = "Together for Victory"
+						has_dlc = "Man the Guns"
+					}
+				}
+
+				POR = {
+					if = {
+						limit = { has_country_flag = POR_released_angola_flag }
+						set_autonomy = {
+						    target = ANG
+						    autonomy_state = autonomy_integrated_puppet
+						}
+					}
+					if = {
+						limit = { has_country_flag = POR_released_mozambique_flag }
+						set_autonomy = {
+						    target = MZB
+						    autonomy_state = autonomy_integrated_puppet
+						}
+					}
+				}
+			}
+			else = {
+				if = {
+					limit = { has_country_flag = POR_released_angola_flag }
+					POR = { puppet = ANG }
+				}
+				if = {
+					limit = { has_country_flag = POR_released_mozambique_flag }
+					POR = { puppet = MZB }
+				}
+			}			
+
+			every_other_country = {
+				limit = { has_government = democratic }
+				add_opinion_modifier = {
+					target = POR
+					modifier = democratic_leanings_good 
+				}
+			}
+
+			if = {
+				limit = {
+					has_completed_focus = POR_allow_free_elections
+				}
+				custom_effect_tooltip = available_political_advisor
+				show_ideas_tooltip = POR_francisco_da_cunha_leal
+			}
+		}
+	}
+
+	focus = {
+		id = POR_infrastructure_in_angola
+		available = {
+			OR = {
+				has_full_control_of_state = 796
+				796 = {
+					owner = { is_subject_of = ROOT }
+				}
+			}
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_colonial_assimilation_policy }	
+			
+		icon = GFX_focus_generic_africa_infrastructure
+		x = 2
+		y = 0
+
+		relative_position_id = POR_limited_self_rule
+		cost = 10
+		search_filters = {FOCUS_FILTER_INDUSTRY}
+		completion_reward = { 
+
+			796 = {		
+				
+				add_building_construction = {
+					type = naval_base
+					level = 2
+					province = 2115
+					instant_build = yes
+				}	
+
+				add_building_construction = {
+					type = infrastructure
+					level = 1
+					instant_build = yes
+				}					
+				add_extra_state_shared_building_slots = 1	
+			}
+
+			540 = {		
+
+				add_building_construction = {
+					type = naval_base
+					level = 3
+					province = 8248
+					instant_build = yes
+				}	
+
+				add_building_construction = {
+					type = infrastructure
+					level = 1
+					instant_build = yes
+				}					
+				add_extra_state_shared_building_slots = 1					
+			}				
+		}
+	}
+
+	focus = {
+		id = POR_develop_north_angola
+		available = {	
+			OR = {
+				has_full_control_of_state = 796
+				796 = {
+					owner = { is_subject_of = ROOT }
+				}
+			}					
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_infrastructure_in_angola }
+		prerequisite = { focus = POR_roads_bridges_and_dams }  	
+			
+		icon = GFX_focus_generic_africa_factory
+		x = 0
+		y = 1
+
+		relative_position_id = POR_infrastructure_in_angola
+		cost = 10
+		search_filters = {FOCUS_FILTER_INDUSTRY}
+		completion_reward = { 
+			796 = {
+				add_extra_state_shared_building_slots = 2
+				add_building_construction = {
+					type = infrastructure
+					level = 1
+					instant_build = yes
+				}
+
+				add_building_construction = {
+					type = industrial_complex
+					level = 1
+					instant_build = yes
+				}
+
+				add_resource = {
+					type = steel
+					amount = 8
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_develop_south_angola
+		available = {
+			OR = {
+				has_full_control_of_state = 540
+				540 = {
+					owner = { is_subject_of = ROOT }
+				}
+			}
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_develop_north_angola }	
+			
+		icon = GFX_focus_generic_africa_production
+		x = 0
+		y = 1
+
+		relative_position_id = POR_develop_north_angola
+		cost = 10
+		search_filters = {FOCUS_FILTER_INDUSTRY}
+		completion_reward = { 
+			540 = {
+				add_extra_state_shared_building_slots = 4
+				add_building_construction = {
+					type = infrastructure
+					level = 1
+					instant_build = yes
+				}
+
+				add_building_construction = {
+					type = industrial_complex
+					level = 1
+					instant_build = yes
+				}
+
+				add_building_construction = {
+					type = naval_base
+					level = 2
+					province = 8248
+					instant_build = yes
+				}
+
+				add_resource = {
+					type = steel
+					amount = 8
+				}
+
+				add_resource = {
+					type = rubber
+					amount = 4
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_portuguese_oil
+		available = {
+			OR = {
+				has_full_control_of_state = 796
+				796 = {
+					owner = { is_subject_of = ROOT }
+				}
+			}
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_develop_south_angola }
+				
+		icon = GFX_goal_generic_oil_refinery
+		x = -1
+		y = 1
+
+		relative_position_id = POR_develop_south_angola
+		cost = 10
+		search_filters = {FOCUS_FILTER_INDUSTRY}
+		completion_reward = { 
+			796 = {
+				add_resource = {
+					type = oil
+					amount = 12
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_develop_mozambique
+		available = {
+			OR = {
+				has_full_control_of_state = 544
+				544 = {
+					owner = { is_subject_of = ROOT }
+				}
+			}
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_develop_south_angola }
+				
+		icon = GFX_focus_generic_africa_naval
+		x = 1
+		y = 1
+
+		relative_position_id = POR_develop_south_angola
+		cost = 10
+		search_filters = {FOCUS_FILTER_INDUSTRY}
+		completion_reward = { 
+			544 = {
+				add_extra_state_shared_building_slots = 4
+				add_building_construction = {
+					type = infrastructure
+					level = 1
+					instant_build = yes
+				}
+
+				add_building_construction = {
+					type = industrial_complex
+					level = 1
+					instant_build = yes
+				}
+
+				add_building_construction = {
+					type = naval_base
+					level = 2
+					province = 2123				
+					instant_build = yes
+				}
+				add_resource = {
+					type = aluminium
+					amount = 12
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_continue_the_public_works
+		available = {
+			OR = {
+				has_full_control_of_state = 180 #PORTO
+				has_full_control_of_state = 181 #GUARDA
+				has_full_control_of_state = 795 #SANTAREM
+				has_full_control_of_state = 179 #BEJA
+				has_full_control_of_state = 112 #LISBON
+			}
+		}
+
+		bypass = {		
+		}
+			
+		icon = GFX_focus_generic_industry_2
+		x = 9
+		y = 0
+
+		relative_position_id = POR_colonial_assimilation_policy
+		cost = 10
+		search_filters = {FOCUS_FILTER_INDUSTRY}
+		completion_reward = {			
+			if = {
+				limit = { has_full_control_of_state = 180 }
+				180 = {
+					add_extra_state_shared_building_slots = 1	
+					add_building_construction = {
+						type = infrastructure
+						level = 1
+						instant_build = yes
+					}
+				}
+			}	
+			
+			if = {
+				limit = { has_full_control_of_state = 181 }
+				181 = {
+					add_extra_state_shared_building_slots = 1	
+					add_building_construction = {
+						type = infrastructure
+						level = 1
+						instant_build = yes
+					}
+				}
+			}
+
+			if = {
+				limit = { has_full_control_of_state = 795 }
+				795 = {
+					add_extra_state_shared_building_slots = 1
+					add_building_construction = {
+						type = infrastructure
+						level = 1
+						instant_build = yes
+					}	
+				}
+			}
+
+			if = {
+				limit = { has_full_control_of_state = 179 }
+				179 = {
+					add_extra_state_shared_building_slots = 1	
+					add_building_construction = {
+						type = infrastructure
+						level = 1
+						instant_build = yes
+					}
+				}
+			}
+
+			if = {
+				limit = { has_full_control_of_state = 112 }
+				112 = {
+					add_extra_state_shared_building_slots = 1	
+					add_building_construction = {
+						type = infrastructure
+						level = 1
+						instant_build = yes
+					}
+
+					add_building_construction = {
+						type = naval_base
+						level = 2
+						province = 11805					
+						instant_build = yes
+					}				
+				}
+			}
+
+			add_ideas = POR_improved_production
+		}
+	}
+
+	focus = {
+		id = POR_instituto_superior_tecnico
+		available = {			
+		}
+
+		bypass = {
+		}
+		prerequisite = { focus = POR_continue_the_public_works }	
+		icon = GFX_focus_research
+		x = 0
+		y = 1
+
+		relative_position_id = POR_continue_the_public_works
+		cost = 10
+		search_filters = {FOCUS_FILTER_RESEARCH}
+		completion_reward = { 	
+			add_research_slot = 1
+		}
+	}
+
+	focus = {
+		id = POR_ogme
+		available = {			
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_instituto_superior_tecnico }	
+		icon = GFX_goal_generic_build_airforce
+		x = -1
+		y = 1
+
+		relative_position_id = POR_instituto_superior_tecnico
+		cost = 10
+		search_filters = {FOCUS_FILTER_INDUSTRY FOCUS_FILTER_RESEARCH}
+		completion_reward = { 
+			if = {
+				limit = { has_full_control_of_state = 112 }
+				112 = {
+					add_extra_state_shared_building_slots = 1
+					add_building_construction = {
+						type = arms_factory
+						level = 1
+						instant_build = yes
+					}
+				}
+			}
+			else = {
+				random_owned_state = {
+					limit = {
+						is_controlled_by = ROOT
+						is_core_of = ROOT
+						free_building_slots = {
+							building = arms_factory
+							size > 1
+							include_locked = yes
+						}
+					}
+					add_extra_state_shared_building_slots = 1
+					add_building_construction = {
+						type = arms_factory
+						level = 1
+						instant_build = yes
+					}
+				}
+			}
+			custom_effect_tooltip = available_designer
+			show_ideas_tooltip = ogme
+		}
+	}
+
+	focus = {
+		id = POR_ogma
+		available = {			
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_instituto_superior_tecnico }	
+		icon = GFX_goal_generic_air_production
+		x = 1
+		y = 1
+
+		relative_position_id = POR_instituto_superior_tecnico
+		cost = 10
+		search_filters = {FOCUS_FILTER_INDUSTRY FOCUS_FILTER_RESEARCH}
+		completion_reward = { 
+			if = {
+				limit = { has_full_control_of_state = 112 }
+				112 = {
+					add_extra_state_shared_building_slots = 1
+					add_building_construction = {
+						type = arms_factory
+						level = 1
+						instant_build = yes
+					}
+				}
+			}
+			else = {
+				random_owned_state = {
+					limit = {
+						is_controlled_by = ROOT
+						is_core_of = ROOT
+						free_building_slots = {
+							building = arms_factory
+							size > 1
+							include_locked = yes
+						}
+					}
+					add_extra_state_shared_building_slots = 1
+					add_building_construction = {
+						type = arms_factory
+						level = 1
+						instant_build = yes
+					}
+				}
+			}
+			custom_effect_tooltip = available_designer
+			show_ideas_tooltip = ogma
+		}
+	}
+
+	focus = {
+		id = POR_roads_bridges_and_dams
+		available = {	
+			OR = {
+				has_full_control_of_state = 181 #GUARDA
+				has_full_control_of_state = 795 #SANTAREM
+				has_full_control_of_state = 179 #BEJA
+				has_full_control_of_state = 180 #PORTO
+				has_full_control_of_state = 112 #LISBON
+			}			
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_instituto_superior_tecnico }	
+		icon = GFX_goal_generic_construct_infrastructure
+		x = 2
+		y = 0
+
+		relative_position_id = POR_infrastructure_in_angola
+		cost = 10
+		search_filters = {FOCUS_FILTER_INDUSTRY}
+		completion_reward = { 
+			if = {
+				limit = { has_full_control_of_state = 181 }
+				181 = {
+					add_extra_state_shared_building_slots = 1
+					add_building_construction = {
+						type = infrastructure
+						level = 1
+						instant_build = yes
+					}
+				}
+			}
+
+			if = {
+				limit = { has_full_control_of_state = 795 }
+				795 = {
+					add_extra_state_shared_building_slots = 1
+					add_building_construction = {
+						type = infrastructure
+						level = 1
+						instant_build = yes
+					}	
+				}
+			}
+
+			if = {
+				limit = { has_full_control_of_state = 179 }
+				179 = {
+					add_extra_state_shared_building_slots = 1
+					add_building_construction = {
+						type = infrastructure
+						level = 1
+						instant_build = yes
+					}
+				}	
+			}
+
+			if = {
+				limit = { has_full_control_of_state = 180 }
+				180 = {
+					add_extra_state_shared_building_slots = 3
+					add_building_construction = {
+						type = infrastructure
+						level = 1
+						instant_build = yes
+					}
+					add_building_construction = {
+						type = naval_base
+						level = 2
+						province = 9817					
+						instant_build = yes
+					}
+				}
+			}
+
+			if = {
+				limit = { has_full_control_of_state = 112 }
+				112 = {
+					add_extra_state_shared_building_slots = 2
+					add_building_construction = {
+						type = infrastructure
+						level = 1
+						instant_build = yes
+					}
+
+					add_building_construction = {
+						type = industrial_complex
+						level = 1	
+						instant_build = yes
+					}				
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_extraction_industries
+		available = {
+			OR = {
+				has_full_control_of_state = 112
+				has_full_control_of_state = 795
+			}			
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_roads_bridges_and_dams }	
+		icon = GFX_goal_generic_construction2
+		x = 0
+		y = 1
+
+		relative_position_id = POR_roads_bridges_and_dams
+		cost = 10
+		search_filters = {FOCUS_FILTER_INDUSTRY}
+		completion_reward = { 	
+			if = {
+				limit = { has_full_control_of_state = 112 }	
+				unlock_decision_tooltip = POR_develop_lisbon_tungsten_deposits
+			}
+			if = {
+				limit = { has_full_control_of_state = 795 }
+				unlock_decision_tooltip = POR_develop_santarem_chromium_deposits
+			}			
+		}
+	}
+
+	focus = {
+		id = POR_hydroelectricity
+		available = {
+			OR = {
+				has_full_control_of_state = 180 #PORTO
+				has_full_control_of_state = 181 #GUARDA
+				has_full_control_of_state = 179 #BEJA
+				has_full_control_of_state = 112 #LISBON
+			}			
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_extraction_industries }	
+		icon = GFX_goal_generic_construction
+		x = 0
+		y = 1
+
+		relative_position_id = POR_extraction_industries
+		cost = 10
+		search_filters = {FOCUS_FILTER_INDUSTRY}
+		completion_reward = { 	
+			add_ideas = POR_hydroelectric_power
+			if = {
+				limit = { has_full_control_of_state = 180 }
+				180 = {
+					add_building_construction = {
+						type = infrastructure
+						level = 1
+						instant_build = yes
+					}
+					add_extra_state_shared_building_slots = 1	
+				}
+			}
+			if = {
+				limit = { has_full_control_of_state = 181 }
+				181 = {
+					add_building_construction = {
+						type = infrastructure
+						level = 1
+						instant_build = yes
+					}
+					add_extra_state_shared_building_slots = 1	
+				}
+			}
+			if = {
+				limit = { has_full_control_of_state = 179 }
+				179 = {
+					add_building_construction = {
+						type = infrastructure
+						level = 1
+						instant_build = yes
+					}
+					add_extra_state_shared_building_slots = 1	
+				}
+			}
+			if = {
+				limit = { has_full_control_of_state = 112 }
+				112 = {
+					add_building_construction = {
+						type = infrastructure
+						level = 1
+						instant_build = yes
+					}			
+					add_extra_state_shared_building_slots = 1	
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_military_vehicles
+		available = {			
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_ogme }	
+
+		icon = GFX_goal_generic_army_motorized
+		x = 0
+		y = 1
+
+		relative_position_id = POR_ogme
+		cost = 10
+		search_filters = {FOCUS_FILTER_RESEARCH FOCUS_FILTER_INDUSTRY}
+		completion_reward = { 			
+			add_tech_bonus = {
+				name = POR_military_vehicles
+			    bonus = 1.0
+			    uses = 1
+			    category = motorized_equipment
+			}
+
+			if = {
+				limit = { has_full_control_of_state = 112 }
+				112 = {
+					add_extra_state_shared_building_slots = 1
+					add_building_construction = {
+						type = arms_factory
+						level = 1
+						instant_build = yes
+					}
+				}
+			}
+			else = {
+				random_owned_state = {
+					limit = {
+						is_controlled_by = ROOT
+						is_core_of = ROOT
+						free_building_slots = {
+							building = arms_factory
+							size > 1
+							include_locked = yes
+						}
+					}
+					add_extra_state_shared_building_slots = 1
+					add_building_construction = {
+						type = arms_factory
+						level = 1
+						instant_build = yes
+					}
+				}
+			}	
+		}
+	}
+
+	focus = {
+		id = POR_portuguese_artillery
+		available = {			
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_ogme }	
+
+		icon = GFX_goal_generic_army_artillery
+		x = -2
+		y = 1
+
+		relative_position_id = POR_ogme
+		cost = 10
+		search_filters = {FOCUS_FILTER_RESEARCH FOCUS_FILTER_INDUSTRY}
+		completion_reward = { 
+			add_tech_bonus = {
+				name = POR_portuguese_artillery
+			    bonus = 1.0
+			    uses = 1
+			    category = artillery
+			}
+
+			if = {
+				limit = { has_full_control_of_state = 179 }
+				179 = {
+					add_extra_state_shared_building_slots = 2
+					add_building_construction = {
+						type = arms_factory
+						level = 2
+						instant_build = yes
+					}			
+				}
+			}
+			else = {
+				random_owned_state = {
+					limit = {
+						is_controlled_by = ROOT
+						is_core_of = ROOT
+						free_building_slots = {
+							building = arms_factory
+							size > 2
+							include_locked = yes
+						}
+					}
+					add_extra_state_shared_building_slots = 2
+					add_building_construction = {
+						type = arms_factory
+						level = 2
+						instant_build = yes
+					}
+				}
+			}
+			custom_effect_tooltip = available_designer
+			show_ideas_tooltip = fma
+		}
+	}
+
+	focus = {
+		id = POR_advanced_artillery
+		available = {			
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_portuguese_artillery}
+		prerequisite = { focus = POR_military_research_facilities}	
+		icon = GFX_goal_generic_army_artillery2
+		x = 0
+		y = 2
+
+		relative_position_id = POR_portuguese_artillery
+		cost = 10
+		search_filters = {FOCUS_FILTER_RESEARCH}
+		completion_reward = { 	
+			add_tech_bonus = {
+				name = POR_advanced_artillery
+			    bonus = 1.0
+			    uses = 2
+			    category = artillery
+			}
+
+			add_tech_bonus = {
+				name = POR_advanced_artillery
+			    bonus = 1.0
+			    uses = 1
+			    category = land_doctrine
+			    category = naval_doctrine
+			    category = air_doctrine
+			}
+		}
+	}
+
+	focus = {
+		id = POR_military_research_facilities
+		available = {	
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_military_vehicles focus = POR_portuguese_artillery focus = POR_light_aircraft_focus }	
+		icon = GFX_focus_research
+		x = 0
+		y = 1
+
+		relative_position_id = POR_military_vehicles
+		cost = 10
+		search_filters = {FOCUS_FILTER_RESEARCH}
+		completion_reward = { 	
+			add_research_slot = 1
+		}
+	}
+
+	focus = {
+		id = POR_armor_focus
+		available = {			
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_military_research_facilities}
+		mutually_exclusive = { focus = POR_advanced_light_aircraft}	
+		icon = GFX_goal_generic_army_tanks
+		x = 0
+		y = 1
+
+		relative_position_id = POR_military_research_facilities
+		cost = 10
+		search_filters = {FOCUS_FILTER_INDUSTRY FOCUS_FILTER_RESEARCH}
+		completion_reward = { 	
+			if = {
+				limit = { has_full_control_of_state = 112 }	
+				112 = {
+					add_extra_state_shared_building_slots = 1
+					add_building_construction = {
+						type = arms_factory		
+						level = 1
+						instant_build = yes
+					}
+				}
+			}
+			else = {
+				random_owned_state = {
+					limit = {
+						is_controlled_by = ROOT
+						is_core_of = ROOT
+						free_building_slots = {
+							building = arms_factory
+							size > 1
+							include_locked = yes
+						}
+					}
+					add_extra_state_shared_building_slots = 1
+					add_building_construction = {
+						type = arms_factory
+						level = 1
+						instant_build = yes
+					}
+				}
+			}
+			add_tech_bonus = {
+				name = POR_armor_focus
+			    bonus = 1.0
+			    uses = 1
+			    category = armor
+			}
+		}
+	}
+
+	focus = {
+		id = POR_mechanized_focus
+		available = {			
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_armor_focus}	
+		icon = GFX_goal_generic_build_tank
+		x = 0
+		y = 1
+
+		relative_position_id = POR_armor_focus
+		cost = 10
+		search_filters = {FOCUS_FILTER_RESEARCH}
+		completion_reward = { 	
+			add_tech_bonus = {
+				name = POR_mechanized_focus
+			    bonus = 1.0
+			    uses = 1
+			    category = cat_mechanized_equipment
+			}
+		}
+	}
+
+	focus = {
+		id = POR_light_aircraft_focus
+		available = {			
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_ogma}	
+		icon = GFX_goal_generic_air_fighter2
+		x = 0
+		y = 1
+
+		relative_position_id = POR_ogma
+		cost = 10
+		search_filters = {FOCUS_FILTER_RESEARCH FOCUS_FILTER_INDUSTRY}
+		completion_reward = { 
+			add_tech_bonus = {
+				name = POR_light_aircraft_focus
+			    bonus = 1.0
+			    uses = 1
+			    category = light_air
+			}
+			if = {
+				limit = { has_full_control_of_state = 112 }
+				112 = {
+					add_extra_state_shared_building_slots = 1
+					add_building_construction = {
+						type = arms_factory		
+						level = 1
+						instant_build = yes
+					}
+				}
+			}
+			else = {
+				random_owned_state = {
+					limit = {
+						is_controlled_by = ROOT
+						is_core_of = ROOT
+						free_building_slots = {
+							building = arms_factory
+							size > 1
+							include_locked = yes
+						}
+					}
+					add_extra_state_shared_building_slots = 1
+					add_building_construction = {
+						type = arms_factory
+						level = 1
+						instant_build = yes
+					}
+				}
+			}
+			air_experience = 25
+		}
+	}
+
+	focus = {
+		id = POR_advanced_light_aircraft
+		available = {			
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_light_aircraft_focus}
+		mutually_exclusive = { focus = POR_armor_focus}	
+		icon = GFX_goal_generic_air_bomber
+		x = 0
+		y = 2
+
+		relative_position_id = POR_light_aircraft_focus
+		cost = 10
+		search_filters = {FOCUS_FILTER_RESEARCH FOCUS_FILTER_INDUSTRY}
+		completion_reward = { 
+			add_tech_bonus = {
+				name = POR_advanced_light_aircraft
+			    bonus = 1.0
+			    uses = 1
+			    category = light_air
+			}
+			air_experience = 50
+			add_ideas = POR_advanced_light_aircraft
+		}
+	}
+
+	focus = {
+		id = POR_jet_research
+		available = {			
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_advanced_light_aircraft}	
+		icon = GFX_goal_generic_air_fighter
+		x = 0
+		y = 1
+
+		relative_position_id = POR_advanced_light_aircraft
+		cost = 10
+		search_filters = {FOCUS_FILTER_RESEARCH}
+		completion_reward = { 	
+			add_tech_bonus = {
+				name = POR_jet_research
+			    bonus = 1.0
+			    uses = 1
+			    category = jet_technology
+			}
+		}
+	}
+
+	focus = {
+		id = POR_industrial_modernization
+		available = {			
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_instituto_superior_tecnico }
+		mutually_exclusive = { focus = POR_food_industries}	
+		icon = GFX_goal_generic_construct_civ_factory
+		x = 3
+		y = 1
+
+		relative_position_id = POR_instituto_superior_tecnico
+		cost = 10
+		search_filters = {FOCUS_FILTER_RESEARCH}
+		completion_reward = { 	
+			add_tech_bonus = {
+				name = POR_industrial_modernization
+			    bonus = 1.0
+			    uses = 2
+			    category = industry
+			}
+		}
+	}
+
+	focus = {
+		id = POR_a_new_industry
+		available = { 
+			has_tech = advanced_machine_tools			
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_industrial_modernization }
+		icon = GFX_focus_generic_industry_3
+		x = 0
+		y = 1
+
+		relative_position_id = POR_industrial_modernization
+		cost = 10
+		search_filters = {FOCUS_FILTER_INDUSTRY}
+		completion_reward = { 
+		   if = {
+				limit = { has_full_control_of_state = 112 }
+			    112 = {
+					add_extra_state_shared_building_slots = 1
+					add_building_construction = {
+						type = industrial_complex		
+						level = 1
+						instant_build = yes
+					}				
+				}
+			}
+			if = {
+				limit = { has_full_control_of_state = 795 }
+				795 = {
+					add_extra_state_shared_building_slots = 1
+					add_building_construction = {
+						type = industrial_complex		
+						level = 1
+						instant_build = yes
+					}
+				}
+			}
+			else = {
+				random_owned_state = {
+					limit = {
+						is_controlled_by = ROOT
+						is_core_of = ROOT
+						free_building_slots = {
+							building = industrial_complex
+							size > 2
+							include_locked = yes
+						}
+					}
+					add_extra_state_shared_building_slots = 1
+					add_building_construction = {
+						type = industrial_complex
+						level = 2
+						instant_build = yes
+					}
+				}
+			}
+			add_ideas = POR_a_new_industry
+		}
+	}
+
+	focus = {
+		id = POR_food_industries
+		available = {
+			OR = {
+				has_full_control_of_state = 180
+				has_full_control_of_state = 181
+			}		
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_continue_the_public_works }
+		mutually_exclusive = { focus = POR_industrial_modernization }	
+		icon = GFX_goal_generic_consumer_goods
+		x = 5
+		y = 2
+
+		relative_position_id = POR_continue_the_public_works
+		cost = 10
+		search_filters = {FOCUS_FILTER_INDUSTRY}
+		completion_reward = { 
+			if = {
+				limit = { has_full_control_of_state = 180 }
+				180 = {
+					add_extra_state_shared_building_slots = 1
+					add_building_construction = {
+						type = industrial_complex		
+						level = 1
+						instant_build = yes
+					}
+				}
+			}
+
+			if = {
+				limit = { has_full_control_of_state = 181 }
+				181 = {
+					add_extra_state_shared_building_slots = 1
+					add_building_construction = {
+						type = industrial_complex		
+						level = 1
+						instant_build = yes
+					}
+				}
+			}	
+		}
+	}
+
+	focus = {
+		id = POR_textile_industry
+		available = {
+			OR = {
+				has_full_control_of_state = 179
+				has_full_control_of_state = 112
+			}			
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_food_industries }			
+		icon = GFX_goal_generic_trade
+		x = 0
+		y = 1
+
+		relative_position_id = POR_food_industries
+		cost = 10
+		search_filters = {FOCUS_FILTER_INDUSTRY}
+		completion_reward = { 	
+			if = {
+				limit = { has_full_control_of_state = 179 }	
+				179 = {
+					add_extra_state_shared_building_slots = 1
+					add_building_construction = {
+						type = industrial_complex		
+						level = 1
+						instant_build = yes
+					}
+				}
+			}
+
+			if = {
+				limit = { has_full_control_of_state = 112 }
+				112 = {
+					add_extra_state_shared_building_slots = 1
+					add_building_construction = {
+						type = industrial_complex		
+						level = 1
+						instant_build = yes
+					}
+				}
+			}
+
+			if = {
+				limit = { has_full_control_of_state = 795 }
+				795 = {
+					add_extra_state_shared_building_slots = 1
+					add_building_construction = {
+						type = industrial_complex		
+						level = 1
+						instant_build = yes
+					}
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_second_navy_reequipment
+		available = {			
+		}
+
+		bypass = {		
+		}
+		prerequisite = {		
+		}			
+		icon = GFX_goal_generic_build_navy
+		x = 9
+		y = 0
+
+		relative_position_id = POR_continue_the_public_works
+		cost = 10
+		search_filters = {FOCUS_FILTER_INDUSTRY}
+		completion_reward = { 
+			if = {
+				limit = { has_full_control_of_state = 112 }
+				112 = {
+					add_extra_state_shared_building_slots = 2
+					add_building_construction = {
+						type = dockyard		
+						level = 2
+						instant_build = yes
+					}
+				}
+			}
+			else = {
+				random_owned_state = {
+					limit = {
+						is_controlled_by = ROOT
+						is_core_of = ROOT
+						free_building_slots = {
+							building = dockyard
+							size > 2
+							include_locked = yes
+						}
+					}
+					add_extra_state_shared_building_slots = 2
+					add_building_construction = {
+						type = dockyard
+						level = 2
+						instant_build = yes
+					}
+				}
+			}
+			unlock_decision_tooltip = POR_buy_ships_britain
+			unlock_decision_tooltip = POR_buy_ships_italy	
+		}
+	}
+
+	focus = {
+		id = POR_a_powerful_merchant_marine
+		available = {			
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_second_navy_reequipment }			
+		icon = GFX_goal_generic_navy_battleship
+		x = 0
+		y = 1
+
+		relative_position_id = POR_second_navy_reequipment
+		cost = 10
+		search_filters = {FOCUS_FILTER_INDUSTRY FOCUS_FILTER_RESEARCH}
+		completion_reward = { 	
+			if = {
+				limit = { has_full_control_of_state = 179 }
+				179 = { #Beja
+					add_extra_state_shared_building_slots = 1
+					add_building_construction = {
+						type = dockyard		
+						level = 1
+						instant_build = yes
+					}
+				}
+			}
+			else = {
+				random_owned_state = {
+					limit = {
+						is_controlled_by = ROOT
+						is_core_of = ROOT
+						free_building_slots = {
+							building = dockyard
+							size > 1
+							include_locked = yes
+						}
+					}
+					add_extra_state_shared_building_slots = 1
+					add_building_construction = {
+						type = dockyard
+						level = 1
+						instant_build = yes
+					}
+				}
+			}
+			if = {
+				limit = { has_full_control_of_state = 180 }
+				180 = { #Porto
+					add_extra_state_shared_building_slots = 1
+					add_building_construction = {
+						type = dockyard		
+						level = 1
+						instant_build = yes
+					}
+				}
+			}
+			else = {
+				random_owned_state = {
+					limit = {
+						is_controlled_by = ROOT
+						is_core_of = ROOT
+						free_building_slots = {
+							building = dockyard
+							size > 1
+							include_locked = yes
+						}
+					}
+					add_extra_state_shared_building_slots = 1
+					add_building_construction = {
+						type = dockyard
+						level = 1
+						instant_build = yes
+					}
+				}
+			}
+			add_tech_bonus = {
+				name = POR_a_powerful_merchant_marine
+			    bonus = 1.0
+			    uses = 1
+			    category = dd_tech			   
+			}
+			add_ideas = POR_convoy_build_efficiency
+		}
+	}
+
+	focus = {
+		id = POR_merchant_marine_protection
+		available = {			
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_a_powerful_merchant_marine }			
+		icon = GFX_goal_generic_amphibious_assault
+		x = 0
+		y = 1
+
+		relative_position_id = POR_a_powerful_merchant_marine
+		cost = 10
+		search_filters = {FOCUS_FILTER_RESEARCH}
+		completion_reward = { 	
+			add_tech_bonus = {
+				name = POR_merchant_marine_protection
+			    bonus = 1.0
+			    uses = 2
+			    category = dd_tech			   
+			}
+
+			if = {
+		    	limit = {
+		    		has_dlc = "Man the Guns"		    		
+		    	}
+		    	add_tech_bonus = {
+		    		name = POR_merchant_marine_protection
+				    bonus = 1.0
+				    uses = 2
+				    category = asw_tech		   
+				}
+		    }						
+		}
+	}
+
+	focus = {
+		id = POR_submarine_effort
+		available = {			
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_second_navy_reequipment }			
+		icon = GFX_goal_generic_navy_submarine
+		x = -2		
+		y = 1
+
+		relative_position_id = POR_second_navy_reequipment
+		cost = 10
+		search_filters = {FOCUS_FILTER_RESEARCH}
+		completion_reward = { 	
+			add_tech_bonus = {
+				name = POR_submarine_effort
+			    bonus = 1.0
+			    uses = 1
+			    category = cat_trade_interdiction			   
+			}
+
+			add_tech_bonus = {
+				name = POR_submarine_effort
+			    bonus = 1.0
+			    uses = 2
+			    category = ss_tech			   
+			}
+		}
+	}
+
+	focus = {
+		id = POR_fuzileiros
+		available = {			
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_submarine_effort}
+		prerequisite = { focus = POR_merchant_marine_protection }
+		icon = GFX_goal_generic_occupy_states_coastal
+		x = 0
+		y = 3
+
+		relative_position_id = POR_submarine_effort
+		cost = 10
+		search_filters = {FOCUS_FILTER_RESEARCH}
+		completion_reward = { 
+			add_tech_bonus = {
+				name = POR_fuzileiros
+			    bonus = 1.0
+			    uses = 2
+			    category = marine_tech			   
+			}
+
+			add_tech_bonus = {
+				name = POR_fuzileiros
+			    bonus = 1.0
+			    uses = 2
+			    category = tp_tech			   
+			}
+			# AI will build the required docks for the next focus
+			add_ai_strategy = {
+				type = building_target
+				id = dockyard
+				value = 15
+			}
+		}
+	}
+
+	focus = {
+		id = POR_naval_research_institute
+		available = {	
+			num_of_naval_factories > 15		
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_fuzileiros }
+		icon = GFX_focus_research
+		x = 0
+		y = 1
+
+		relative_position_id = POR_fuzileiros 
+		cost = 10
+		search_filters = {FOCUS_FILTER_RESEARCH}
+		completion_reward = { 
+			navy_experience = 50
+			add_research_slot = 1
+		}
+	}
+
+	focus = {
+		id = POR_air_naval_research
+		available = {			
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_naval_research_institute }
+		prerequisite = { focus = POR_advanced_light_aircraft }			
+		icon = GFX_goal_generic_air_naval_bomber
+		x = 0
+		y = 1
+
+		relative_position_id = POR_naval_research_institute 
+		cost = 10
+		completion_reward = { 	
+			navy_experience = 50
+			air_experience = 50
+		}
+	}
+
+	focus = {
+		id = POR_arsenal_do_alfeite
+		available = {
+			has_full_control_of_state = 112		
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_second_navy_reequipment }			
+		icon = GFX_goal_generic_navy_cruiser
+		x = 2		
+		y = 1
+
+		relative_position_id = POR_second_navy_reequipment
+		cost = 20
+		search_filters = {FOCUS_FILTER_RESEARCH FOCUS_FILTER_INDUSTRY}
+		completion_reward = { 	
+			add_tech_bonus = {
+				name = POR_arsenal_do_alfeite
+			    bonus = 1.0
+			    uses = 1
+			    category = ca_tech	   
+			}
+			add_tech_bonus = {
+				name = POR_arsenal_do_alfeite
+			    bonus = 1.0
+			    uses = 1
+			    category = cl_tech	   
+			}
+
+			112 = { #Lisbon
+				add_extra_state_shared_building_slots = 2
+				add_building_construction = {
+					type = dockyard		
+					level = 3
+					instant_build = yes
+				}
+
+				add_building_construction = {
+					type = naval_base		
+					level = 2
+					instant_build = yes
+					province = 11805
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_national_cruiser_production
+		available = {			
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_arsenal_do_alfeite }			
+		icon = GFX_goal_generic_construct_naval_dockyard
+		x = 0		
+		y = 1
+
+		relative_position_id = POR_arsenal_do_alfeite
+		cost = 10
+		search_filters = {FOCUS_FILTER_RESEARCH}
+		completion_reward = { 	
+			add_tech_bonus = {
+				name = POR_national_cruiser_production
+			    bonus = 1.0
+			    uses = 1
+			    category = ca_tech	   
+			}
+			add_tech_bonus = {
+				name = POR_national_cruiser_production
+			    bonus = 1.0
+			    uses = 1
+			    category = cl_tech	   
+			}
+
+			navy_experience = 50
+		}
+	}
+
+	focus = {
+		id = POR_battleship_effort
+		available = {			
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_national_cruiser_production }			
+		icon = GFX_focus_generic_navy_battleship2
+		x = -1		
+		y = 1
+
+		relative_position_id = POR_national_cruiser_production
+		cost = 10
+		search_filters = {FOCUS_FILTER_RESEARCH}
+		completion_reward = {
+			add_tech_bonus = {
+				name = POR_battleship_effort
+			    bonus = 1.0
+			    uses = 2
+			    category = bb_tech	   
+			}
+			add_tech_bonus = {
+				name = POR_battleship_effort
+			    bonus = 1.0
+			    uses = 1
+			    category = cat_fleet_in_being	   
+			}
+		}
+	}
+
+	focus = {
+		id = POR_carrier_effort
+		available = {			
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_national_cruiser_production }			
+		icon = GFX_goal_generic_navy_carrier
+		x = 1		
+		y = 1
+
+		relative_position_id = POR_national_cruiser_production
+		cost = 10
+		search_filters = {FOCUS_FILTER_RESEARCH}
+		completion_reward = { 	
+			add_tech_bonus = {
+				name = POR_carrier_effort
+			    bonus = 1.0
+			    uses = 2
+			    category = cv_tech	   
+			}
+
+			add_tech_bonus = {
+				name = POR_carrier_effort
+			    bonus = 1.0
+			    uses = 1
+			    category = base_strike_main   
+			}
+		}
+	}
+
+	focus = {
+		id = POR_atlantic_defense_strategy
+		available = {
+			OR = {
+				has_full_control_of_state = 698
+				has_full_control_of_state = 697
+				has_full_control_of_state = 702
+			}			
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_national_cruiser_production }			
+		icon = GFX_focus_generic_destroyer
+		x = 0		
+		y = 2
+
+		relative_position_id = POR_national_cruiser_production
+		cost = 10
+		completion_reward = { 
+			if = {
+				limit = { has_full_control_of_state = 698 }
+				698 = { #Azores
+					add_building_construction = {
+						type = coastal_bunker		
+						level = 2
+						province = 1751
+						instant_build = yes
+					}
+
+					add_building_construction = {
+						type = air_base	
+						level = 1
+						instant_build = yes
+					}
+				}
+			}
+
+			if = {
+				limit = { has_full_control_of_state = 697 }
+				697 = { #Madeira
+					add_building_construction = {
+						type = coastal_bunker		
+						level = 1
+						province = 3118
+						instant_build = yes
+					}
+
+					add_building_construction = {
+						type = air_base	
+						level = 1
+						instant_build = yes
+					}
+				}
+			}
+
+			if = {
+				limit = { has_full_control_of_state = 702 }
+				702 = { #Cape Verde
+					add_building_construction = {
+						type = coastal_bunker		
+						level = 1
+						province = 13014
+						instant_build = yes
+					}
+
+					add_building_construction = {
+						type = air_base	
+						level = 1
+						instant_build = yes
+					}
+				}
+			}			
+		}
+	}
+
+	focus = {
+		id = POR_endless_sea
+		available = {
+			OR = {
+				has_full_control_of_state = 321
+				has_full_control_of_state = 729
+				has_full_control_of_state = 721
+			}
+		}
+
+		bypass = {
+		}
+		prerequisite = { focus = POR_atlantic_defense_strategy }
+		icon = GFX_focus_generic_coastal_fort
+		x = 0
+		y = 1
+
+		relative_position_id = POR_atlantic_defense_strategy
+		cost = 20
+		search_filters = {FOCUS_FILTER_INDUSTRY}
+		completion_reward = {
+			add_ideas = POR_endless_sea
+ 			if = {
+				limit = { has_full_control_of_state = 321 }
+	 			321 = { #Goa
+					add_building_construction = {
+						type = coastal_bunker
+						level = 1
+						province = 1273
+						instant_build = yes
+					}
+
+					add_building_construction = {
+						type = bunker
+						level = 1
+						province = 1273
+						instant_build = yes
+					}
+
+					add_building_construction = {
+						type = air_base
+						level = 1
+						instant_build = yes
+					}
+				}
+			}
+			if = {
+				limit = { has_full_control_of_state = 729 }
+				729 = { #Macau
+					add_building_construction = {
+						type = coastal_bunker
+						level = 1
+						province = 4189
+						instant_build = yes
+					}
+
+					add_building_construction = {
+						type = bunker
+						level = 1
+						province = 4189
+						instant_build = yes
+					}
+
+					add_building_construction = {
+						type = air_base
+						level = 1
+						instant_build = yes
+					}
+				}
+			}
+			if = {
+				limit = { has_full_control_of_state = 721 }
+				721 = { #Portuguese Timor
+					add_building_construction = {
+						type = coastal_bunker
+						level = 1
+						province = 12190
+						instant_build = yes
+					}
+
+					add_building_construction = {
+						type = bunker
+						level = 1
+						province = 12190
+						instant_build = yes
+					}
+
+					add_building_construction = {
+						type = air_base
+						level = 1
+						instant_build = yes
+					}
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_army_reorganization
+		available = {			
+		}
+
+		bypass = {		
+		}
+		prerequisite = {
+		}
+		icon = GFX_focus_generic_combined_arms
+		x = 7	
+		y = 0
+
+		relative_position_id = POR_second_navy_reequipment
+		cost = 10
+		search_filters = {FOCUS_FILTER_MANPOWER FOCUS_FILTER_WAR_SUPPORT}
+		completion_reward = { 	
+			remove_ideas = POR_unreliable_army
+			army_experience	= 15
+			add_stability = -0.05
+		}
+	}
+
+	focus = {
+		id = POR_metropolitan_army
+		available = {			
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_army_reorganization }
+		icon = GFX_focus_eng_move_to_secure_the_dominions
+		x = -1		
+		y = 1
+
+		relative_position_id = POR_army_reorganization
+		cost = 10
+		search_filters = {FOCUS_FILTER_RESEARCH}
+		completion_reward = { 	
+			army_experience	= 20
+			add_tech_bonus = {
+				name = POR_metropolitan_army
+			    bonus = 1.0
+			    uses = 2
+			    category = infantry_weapons
+				category = armor
+				category = artillery
+			}
+		}
+	}
+
+	focus = {
+		id = POR_standardization
+		available = {			
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_metropolitan_army }
+		icon = GFX_focus_generic_rubber
+		x = 0		
+		y = 1
+
+		relative_position_id = POR_metropolitan_army
+		cost = 10
+		search_filters = {FOCUS_FILTER_INDUSTRY}
+		completion_reward = { 	
+			add_ideas = POR_standardization
+		}
+	}
+
+	focus = {
+		id = POR_defend_the_borders
+		available = {
+			OR = {
+				has_full_control_of_state = 112
+				has_full_control_of_state = 180
+				has_full_control_of_state = 179
+			}			
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_standardization }
+		mutually_exclusive = { focus = POR_rebuild_the_lines_of_torres_vedras }
+		icon = GFX_focus_generic_provoke_border_clashes
+		x = -1		
+		y = 1
+
+		relative_position_id = POR_standardization
+		cost = 10
+		completion_reward = { 
+		#Add coastal fort to each port
+			if = {
+				limit = { has_full_control_of_state = 112 }
+				112 = { #Lisbon
+					add_building_construction = {
+						type = coastal_bunker
+						province = {
+							all_provinces = yes
+							limit_to_naval_base = yes
+						}
+						level = 1
+						instant_build = yes
+					}
+					add_building_construction = {
+					    type = bunker
+					    province = {
+					        all_provinces = yes
+					        limit_to_border = yes
+					    }
+					    level = 1
+					    instant_build = yes
+					}
+				}
+			}
+			if = {
+				limit = { has_full_control_of_state = 180 }
+				180 = { #Porto
+					add_building_construction = {
+						type = coastal_bunker
+						province = {
+							all_provinces = yes
+							limit_to_naval_base = yes
+						}
+						level = 1
+						instant_build = yes
+					}
+					add_building_construction = {
+					    type = bunker
+					    level = 1
+					    instant_build = yes
+					    province = {
+					        all_provinces = yes
+					        limit_to_border = yes
+					    }
+					}
+				}
+			}
+			if = {
+				limit = { has_full_control_of_state = 179 }
+				179 = { #Beja
+					add_building_construction = {
+						type = coastal_bunker
+						province = {
+							all_provinces = yes
+							limit_to_naval_base = yes
+						}
+						level = 1
+						instant_build = yes
+					}
+					add_building_construction = {
+					    type = bunker
+					    level = 1
+					    instant_build = yes
+					    province = {
+					        all_provinces = yes
+					        limit_to_border = yes
+					    }
+					}
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_rebuild_the_lines_of_torres_vedras
+		available = {
+			has_full_control_of_state = 112		
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_standardization }
+		mutually_exclusive = { focus = POR_defend_the_borders }
+		icon = GFX_goal_generic_defence
+		x = 1		
+		y = 1
+
+		relative_position_id = POR_standardization
+		cost = 10
+		completion_reward = { 
+			112 = { #Lisbon
+				add_building_construction = {
+				    type = bunker
+				    level = 3
+				    instant_build = yes
+				    province = {
+				        all_provinces = yes
+				        limit_to_border = yes
+				    }
+				}
+
+				add_building_construction = {
+				    type = coastal_bunker
+				    level = 2
+				    instant_build = yes	
+				    province = 11805			    
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_tropas_paraquedistas
+		available = {	
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_defend_the_borders focus = POR_rebuild_the_lines_of_torres_vedras }	
+
+		icon = GFX_focus_generic_paratrooper
+		x = 1
+		y = 1
+
+		relative_position_id = POR_defend_the_borders
+		cost = 10
+
+		search_filters = {FOCUS_FILTER_RESEARCH}
+
+		completion_reward = { 
+			add_tech_bonus = {
+				name = POR_tropas_paraquedistas
+				bonus = 2.0
+				uses = 1
+				category = para_tech
+			}
+		}
+	}
+
+	focus = {
+		id = POR_regimento_de_comandos
+		available = {	
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_tropas_paraquedistas }	
+		icon = GFX_goal_generic_special_forces
+		x = 0
+		y = 1
+
+		relative_position_id = POR_tropas_paraquedistas
+		cost = 10
+
+		search_filters = {FOCUS_FILTER_RESEARCH}
+
+		completion_reward = {
+			add_ideas = special_forces
+			add_tech_bonus = {
+				name = POR_regimento_de_comandos
+				bonus = 1.0
+				uses = 2
+				technology = paratroopers
+				technology = paratroopers2
+				technology = marines
+				technology = marines2
+				technology = tech_mountaineers
+				technology = tech_mountaineers2
+			}
+		}
+	}
+
+	focus = {
+		id = POR_corpo_do_estado_maior
+		available = {			
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_army_reorganization }
+		icon = GFX_goal_generic_army_doctrines
+		x = 1		
+		y = 1
+
+		relative_position_id = POR_army_reorganization
+		cost = 10
+		completion_reward = { 	
+			add_ideas = POR_corpo_do_estado_maior	
+			army_experience = 20
+		}
+	}
+
+	focus = {
+		id = POR_staff_wargames
+		available = {			
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_corpo_do_estado_maior }
+		icon = GFX_focus_generic_license_production
+		x = 0		
+		y = 1
+
+		relative_position_id = POR_corpo_do_estado_maior
+		cost = 10
+		search_filters = {FOCUS_FILTER_RESEARCH}
+		completion_reward = {
+			add_tech_bonus = {
+				name = POR_staff_wargames
+			    bonus = 1.0
+			    uses = 2
+			    category = land_doctrine
+			}
+		}
+	}
+
+	focus = {
+		id = POR_field_maneuvers
+		available = {	
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_staff_wargames }	
+		icon = GFX_focus_generic_manpower
+		x = 1
+		y = 1
+
+		relative_position_id = POR_staff_wargames
+		cost = 10
+
+		search_filters = {FOCUS_FILTER_RESEARCH}
+
+		completion_reward = { 
+			army_experience = 15
+			add_tech_bonus = {
+				name = POR_field_maneuvers
+			    bonus = 1.0
+			    uses = 1
+			    category = land_doctrine
+			}
+		}
+	}
+
+	focus = {
+		id = POR_popular_front
+		available = {			
+		}
+
+		bypass = {		
+		}
+		mutually_exclusive = { focus = POR_estado_novo}
+		prerequisite = {		
+		}			
+		icon = GFX_focus_generic_strike_at_democracy1
+		x = 9
+		y = 0
+
+		relative_position_id = POR_army_reorganization
+		cost = 10
+		search_filters = {FOCUS_FILTER_POLITICAL}
+		completion_reward = {
+			set_party_name = { 
+			    ideology = communism
+			    long_name = POR_communism2_party_long
+			    name = POR_communism2_party
+			}
+
+			add_popularity = {
+			    ideology = communism
+			    popularity = 0.05
+			}
+			add_popularity = {
+			    ideology = democratic
+			    popularity = 0.05
+			}
+			add_ideas = internationalism
+			add_political_power = 100
+			custom_effect_tooltip = available_political_advisor
+			show_ideas_tooltip = POR_maria_lamas
+			custom_effect_tooltip = remove_political_advisor
+			show_ideas_tooltip = POR_fernando_dos_santos_costa
+			show_ideas_tooltip = POR_jose_adriano_pequito_rebelo
+			custom_effect_tooltip = remove_chief_of_army
+			show_ideas_tooltip = POR_rolao_preto
+		}
+	}
+
+	focus = {
+		id = POR_nation_in_arms
+		available = {		
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_popular_front }			
+		icon = GFX_focus_generic_attack_portugal
+		x = -5
+		y = 1
+
+		relative_position_id = POR_popular_front
+		cost = 10
+		search_filters = {FOCUS_FILTER_POLITICAL FOCUS_FILTER_WAR_SUPPORT FOCUS_FILTER_MANPOWER}
+		completion_reward = { 
+			add_popularity = {
+			    ideology = communism
+			    popularity = 0.1
+			}
+			add_war_support = 0.1
+			add_ideas = POR_nation_in_arms
+		}
+	}
+
+	focus = {
+		id = POR_unify_leftist_youth_wings
+		available = {
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_nation_in_arms }
+		icon = GFX_goal_generic_war_with_comintern
+		x = -1		
+		y = 1
+
+		relative_position_id = POR_nation_in_arms
+		cost = 10
+		search_filters = {FOCUS_FILTER_POLITICAL}
+		completion_reward = {
+			add_popularity = {
+			    ideology = communism
+			    popularity = 0.05
+			}
+			add_ideas = POR_unified_youth_wings
+		}
+	}
+
+	focus = {
+		id = POR_nationalize_industry
+		available = {
+			OR = {
+				has_full_control_of_state = 112
+				has_full_control_of_state = 180
+				has_full_control_of_state = 181
+				has_full_control_of_state = 795
+			}
+		}
+
+		bypass = {
+			NOT = { has_full_control_of_state = 112 }
+			NOT = { has_full_control_of_state = 180 }
+			NOT = { has_full_control_of_state = 181 }
+			NOT = { has_full_control_of_state = 795 }
+		}
+		prerequisite = { focus = POR_nation_in_arms }
+		icon = GFX_goal_generic_soviet_construction
+		x = 1		
+		y = 1
+
+		relative_position_id = POR_nation_in_arms
+		cost = 10
+		search_filters = {FOCUS_FILTER_INDUSTRY}
+		completion_reward = { 
+			if = {
+				limit = { has_full_control_of_state = 112 }
+				112 = { #Lisbon
+					add_extra_state_shared_building_slots = 2
+					add_building_construction = {
+						type = industrial_complex		
+						level = 2
+						instant_build = yes
+					}				
+				}
+			}
+			if = {
+				limit = { has_full_control_of_state = 180 }
+				180 = { #Porto
+					add_extra_state_shared_building_slots = 1
+					add_building_construction = {
+						type = industrial_complex		
+						level = 1
+						instant_build = yes
+					}				
+				}
+			}
+			if = {
+				limit = { has_full_control_of_state = 181 }
+				181 = { #Guarda
+					add_extra_state_shared_building_slots = 1
+					add_building_construction = {
+						type = industrial_complex		
+						level = 1
+						instant_build = yes
+					}				
+				}
+			}
+			if = {
+				limit = { has_full_control_of_state = 795 }
+				795 = { #Santarem
+					add_extra_state_shared_building_slots = 1
+					add_building_construction = {
+						type = industrial_complex		
+						level = 1
+						instant_build = yes
+					}				
+				}
+			}
+			add_stability = -0.20	
+		}
+	}
+
+	focus = {
+		id = POR_reorganization_of_the_communist_party
+		available = {
+			communism > 0.4
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_nationalize_industry }
+		prerequisite = { focus = POR_unify_leftist_youth_wings }
+		icon = GFX_focus_generic_soviet_politics
+		x = -1		
+		y = 1
+
+		relative_position_id = POR_nationalize_industry
+		cost = 10
+		search_filters = {FOCUS_FILTER_POLITICAL FOCUS_FILTER_INDUSTRY FOCUS_FILTER_STABILITY}
+		completion_reward = {
+			SOV = {
+				if = {
+					limit = { has_government = communism }
+					add_opinion_modifier = {
+					    target = POR
+					    modifier = POR_neutrality_opinion_communism
+					}
+				}					
+			}
+			custom_effect_tooltip = available_political_advisor
+			show_ideas_tooltip = POR_bento_de_jesus_caraca
+			remove_ideas = POR_unstable_republic 
+			if = {
+				limit = {
+					NOT = { has_government = communism }
+				}
+				set_politics = {
+					ruling_party = communism
+				}
+
+				if = { #Low Stability triggers a Civil War
+					limit = {
+						has_stability < 0.4
+					}
+					set_temp_variable = { POR_communist_cw_opposition = party_popularity@neutrality }
+					multiply_temp_variable = { POR_communist_cw_opposition = 0.8 }
+					add_to_temp_variable = { POR_communist_cw_opposition = party_popularity@democratic }
+					add_to_temp_variable = { POR_communist_cw_opposition = party_popularity@fascism }
+					start_civil_war = {	
+						ideology = neutrality
+						size = POR_communist_cw_opposition
+						capital = 180
+						states = { 181 }
+					}
+				}
+				else = {
+					add_stability = -0.1
+				}
+				custom_effect_tooltip = POR_potential_civil_war_low_requirement_tt
+			}
+			else = {
+				add_political_power = 120
+				add_popularity = {
+				    ideology = communism
+				    popularity = 0.05
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_join_the_comintern
+		available = {
+			is_in_faction = no
+			SOV = { is_faction_leader = yes }
+			NOT = { has_war_with = SOV }
+			has_government = communism	
+		}
+
+		bypass = {	
+			is_in_faction_with = SOV
+		}
+		prerequisite = { focus = POR_reorganization_of_the_communist_party }	
+		mutually_exclusive = { focus = POR_the_popular_front_bloc }
+		icon = GFX_focus_generic_join_comintern
+		x = 0		
+		y = 3
+
+		relative_position_id = POR_nation_in_arms
+		cost = 10
+		completion_reward = { 	
+			SOV = {
+				country_event = { id = generic.2 hours = 4 }
+			}		
+		}
+	}
+
+	focus = {
+		id = POR_research_collaboration
+		available = {
+			is_in_faction_with = SOV			
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_join_the_comintern }			
+		icon = GFX_focus_generic_socialist_science
+		x = -1		
+		y = 1
+
+		relative_position_id = POR_join_the_comintern
+		cost = 10
+		search_filters = {FOCUS_FILTER_RESEARCH}
+		completion_reward = { 	
+			SOV = { add_to_tech_sharing_group = comintern_research }
+			add_to_tech_sharing_group = comintern_research
+		}
+	}
+
+	focus = {
+		id = POR_cooperate_with_french_militants
+		available = {
+			any_other_country = {
+				has_government = fascism
+				has_war_with = FRA
+			}
+		}
+
+		bypass = {
+			NOT = {
+				any_other_country = {
+					has_government = fascism
+					has_war_with = FRA
+				}
+			}		
+		}
+		prerequisite = { focus = POR_join_the_comintern  focus = POR_the_popular_front_bloc}			
+		icon = GFX_focus_chi_reach_out_to_france
+		x = 1		
+		y = 1
+
+		relative_position_id = POR_join_the_comintern
+		cost = 10
+		completion_reward = { 	
+			hidden_effect = {
+				add_equipment_to_stockpile = {
+					type = infantry_equipment
+					amount = 1000
+				}
+				add_equipment_to_stockpile = {
+					type = artillery_equipment
+					amount = 1000
+				}
+			}
+
+			send_equipment = {
+			    equipment = infantry_equipment
+			    amount = 1000
+			    target = FRA
+			}
+
+			send_equipment = {
+			    equipment = artillery_equipment
+			    amount = 1000
+			    target = FRA
+			}
+
+			add_ai_strategy = {
+				type = befriend
+				id = FRA
+				value = 100
+			}
+			FRA = {
+				add_ai_strategy = {
+					type = befriend
+					id = ROOT
+					value = 100
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_anti_fascism
+
+		select_effect = {
+			every_country = {
+				limit = {
+					has_government = fascism
+					NOT = { is_in_faction_with = ROOT }
+					OR = {
+						is_major = yes
+						is_neighbor_of = ROOT
+					}
+				}
+				ROOT = {
+					add_ai_strategy = {
+						type = prepare_for_war
+						id = PREV
+						value = 100
+					}
+				}
+			}
+		}
+
+		available = {
+			any_country = {
+				has_government = fascism
+				NOT = { is_in_faction_with = ROOT }
+				OR = {
+					is_major = yes
+					is_neighbor_of = ROOT
+				}
+			}
+		}
+
+		bypass = {
+		}
+		prerequisite = { focus = POR_cooperate_with_french_militants }			
+		icon = GFX_focus_generic_anti_fascist_diplomacy
+		x = 0		
+		y = 1
+
+		relative_position_id = POR_cooperate_with_french_militants
+		cost = 10
+		completion_reward = {
+			hidden_effect = {
+				every_country = {
+					limit = {
+						has_government = fascism
+						NOT = { is_in_faction_with = ROOT }
+						OR = {
+							is_major = yes
+							is_neighbor_of = ROOT
+						}
+					}
+					ROOT = {
+						create_wargoal = {
+							target = PREV
+							type = topple_government
+							expire = 0
+						}
+					}
+				}
+			}
+			custom_effect_tooltip = POR_anti_fascism_tt
+			every_country = { #TOOLTIP Support
+				limit = {
+					has_government = fascism
+					NOT = { is_in_faction_with = ROOT }
+					OR = {
+						is_major = yes
+						is_neighbor_of = ROOT
+					}
+				}
+			}
+
+			hidden_effect = {
+				random_country = {
+					limit = {
+						has_government = fascism
+						NOT = { is_in_faction_with = ROOT }
+						OR = {
+							is_major = yes
+							is_neighbor_of = ROOT
+						}
+					}
+					ROOT = {
+						add_ai_strategy = {
+							type = declare_war
+							id = PREV
+							value = 100
+						}
+					}
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_support_the_spanish_republic
+		available = {
+			SPR_scw_in_progress = yes
+			if = {
+				limit = {
+					NOT = { has_global_flag = spanish_civil_war }
+				}
+				custom_trigger_tooltip = {
+				    tooltip = POR_spr_tooltip_country_exist_tt
+				    country_exists = SPR
+			    }
+			    custom_trigger_tooltip = {
+				    tooltip = POR_spr_tooltip_at_peace_tt
+					NOT = { has_war_with = SPR }
+			    }
+			}	
+		}
+
+		bypass = {
+			OR = {
+				has_global_flag = scw_over
+				if = { 
+					limit = { NOT = { has_global_flag = spanish_civil_war } }
+					NOT = { country_exists = SPR }
+				}
+				else = {
+					NOT = { country_exists = SPD }
+				}
+			}
+		}
+		prerequisite = { focus = POR_popular_front }
+		mutually_exclusive = { focus = POR_strict_neutrality_in_the_spanish_civil_war focus = POR_support_the_spanish_nationalists focus = POR_a_royal_wedding }				
+		icon = GFX_goal_support_communism
+		x = 0
+		y = 1
+
+		relative_position_id = POR_popular_front
+		cost = 10
+		completion_reward = {
+			if = {
+				limit = {
+					NOT = { has_global_flag = spanish_civil_war }
+				}
+				custom_effect_tooltip = POR_spanish_republic_tt
+			} 	
+			SPD = {
+				add_opinion_modifier = {
+				    target = POR
+				    modifier = POR_helped_in_civil_war
+				}
+				add_manpower = 10000
+			}			
+			add_ideas = POR_volunteers_in_the_war_republican
+			add_manpower = -10000
+			hidden_effect = {
+				add_equipment_to_stockpile = {
+					type = infantry_equipment
+					amount = 2000
+				}
+				send_equipment = {
+				    equipment = infantry_equipment
+				    amount = 2000
+				    target = SPD
+				}
+			}
+			custom_effect_tooltip = POR_support_the_spanish_republic_effect_tooltip_tt
+			set_rule = { can_send_volunteers = yes }
+		}
+	}
+
+	focus = {
+		id = POR_workers_of_iberia_unite
+		available = {
+			SPR_scw_in_progress = yes
+			if = {
+				limit = {
+					NOT = { has_global_flag = spanish_civil_war }
+				}
+				custom_trigger_tooltip = {
+				    tooltip = POR_spr_tooltip_country_exist_tt
+				    country_exists = SPR
+			    }
+			    custom_trigger_tooltip = {
+				    tooltip = POR_spr_tooltip_at_peace_tt
+					NOT = { has_war_with = SPR }
+			    }
+			}
+			else = {
+				country_exists = SPD
+				NOT = {has_war_with = SPD }
+			}
+			is_puppet = no
+		}
+
+		bypass = {
+			has_global_flag = scw_over
+		}
+		prerequisite = { focus = POR_support_the_spanish_republic }	
+		mutually_exclusive = { focus = POR_visit_the_front }		
+		icon = GFX_focus_por_workers_of_iberia
+		x = -2		
+		y = 1
+
+		relative_position_id = POR_support_the_spanish_republic
+		cost = 10
+		search_filters = {FOCUS_FILTER_POLITICAL}
+		completion_reward = {
+			# Event that add NS to POR and SPD
+			hidden_effect = {				
+				country_event = {
+					id = lar_portugal_iberian_workers_united.1
+					hours = 6
+				}
+				SPD = {
+					country_event = {
+						id = lar_portugal_iberian_workers_united.1
+						hours = 6
+					}
+				}
+			}
+			custom_effect_tooltip = POR_iberian_workers_effect_tooltip_tt
+			#Trigger civil war
+			if = {
+				limit = {
+					NOT = { has_government = communism }
+				}
+				set_politics = {
+					ruling_party = communism
+				}
+			}
+			if = {
+				limit = {
+					has_civil_war = no
+				}
+				set_temp_variable = { POR_communist_cw_opposition = party_popularity@democratic }
+				multiply_temp_variable = { POR_communist_cw_opposition = 0.8 }
+				add_to_temp_variable = { POR_communist_cw_opposition = party_popularity@neutrality }
+				add_to_temp_variable = { POR_communist_cw_opposition = party_popularity@fascism }
+				hidden_effect = {
+					start_civil_war = {	
+						ideology = neutrality
+						size = POR_communist_cw_opposition
+						capital = 180
+						states = { 181 }
+					}
+				}
+				custom_effect_tooltip = POR_workers_of_iberia_unite_civil_war_tt				
+			}
+			else = {
+				add_stability = -0.2
+			}
+			hidden_effect = {
+				set_country_flag = supports_SPD_flag
+			}
+			#Communist Portugal joins SPD
+			if = {
+				limit = { country_exists = SPA }
+				add_to_war = { targeted_alliance = SPD enemy = SPA hostility_reason = asked_to_join }
+			}
+			if = {
+				limit = { country_exists = SPC }
+				add_to_war = { targeted_alliance = SPD enemy = SPC hostility_reason = asked_to_join }
+			}
+			if = {
+				limit = { country_exists = SPB }
+				add_to_war = { targeted_alliance = SPD enemy = SPB hostility_reason = asked_to_join }
+			}
+			effect_tooltip = {
+				give_military_access = SPD
+				SPD = { give_military_access = ROOT }
+			}
+			hidden_effect = {
+				#Grant military access
+				diplomatic_relation = {
+					country = SPD
+					relation = military_access
+					active = yes
+				}
+				SPD = {
+					diplomatic_relation = {
+						country = POR
+						relation = military_access
+						active = yes
+					}
+				}
+			}
+			#Non-Aligned Portugal joins SPA
+			hidden_effect = {
+				random_country = {
+					limit = {
+						original_tag = POR
+						has_government = neutrality
+					}
+					set_country_flag = POR_non_aligned_portugal_supports_SPA_flag
+					if = {
+						limit = { country_exists = SPA }
+						add_to_war = { targeted_alliance = SPA enemy = SPD hostility_reason = asked_to_join }
+						if = {
+							limit = { country_exists = SPC }
+							add_to_war = { targeted_alliance = SPA enemy = SPC hostility_reason = asked_to_join }
+						}
+						if = {
+							limit = { country_exists = SPB }
+							add_to_war = { targeted_alliance = SPA enemy = SPB hostility_reason = asked_to_join }
+						}
+					}
+				}
+			}
+			custom_effect_tooltip = POR_fascist_portugal_joins_scw_tt
+
+			hidden_effect = {
+				add_ai_strategy = {
+					type = befriend
+					id = SPD
+					value = 100
+				}
+				SPD = {
+					add_ai_strategy = {
+						type = befriend
+						id = ROOT
+						value = 100
+					}
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_the_iberian_socialist_union
+		available = {
+			has_government = communism
+			has_global_flag = scw_over
+		}
+
+		bypass = {
+		}
+		prerequisite = { focus = POR_workers_of_iberia_unite }			
+		icon = GFX_focus_generic_befriend_portugal
+		x = 0		
+		y = 1
+
+		relative_position_id = POR_workers_of_iberia_unite
+		cost = 10
+		search_filters = {FOCUS_FILTER_ANNEXATION}
+		completion_reward = {
+			if = {
+				limit = {
+					NOT = { has_global_flag = spanish_civil_war }
+				}
+				effect_tooltip = {
+					custom_effect_tooltip = POR_the_iberian_socialist_union_cosmetic_name_tt
+					hidden_effect = {
+						every_state = {
+							limit = {
+								OR = {
+									state = 118
+									has_state_flag = SPR_core_of_spain_flag
+								}
+							}
+							add_core_of = ROOT
+						}
+					}
+					custom_effect_tooltip = POR_the_iberian_socialist_union_cores_tt
+					custom_effect_tooltip = POR_the_iberian_socialist_union_annex_puppets_tt
+					custom_effect_tooltip = POR_the_iberian_socialist_union_tt
+					every_country = {
+						limit = {
+							OR = {
+								tag = GLC
+								tag = NAV
+								tag = CAT
+								tag = ADU
+							}
+							NOT = { has_war_with = ROOT }
+							NOT = { is_puppet_of = ROOT }
+						}
+						country_event = { id = lar_portugal_iberian_workers_united.2 hours = 6 }
+					}
+				}
+			}
+			else = {
+				hidden_effect = {
+					set_cosmetic_tag = ESU_POR_unified
+				}
+				custom_effect_tooltip = POR_the_iberian_socialist_union_cosmetic_name_tt
+				#Get cores on all Spanish cores and Gibraltar
+				hidden_effect = {
+					every_state = {
+						limit = {
+							OR = {
+								state = 118
+								has_state_flag = SPR_core_of_spain_flag
+							}
+						}
+						add_core_of = ROOT
+					}
+				}
+				custom_effect_tooltip = POR_the_iberian_socialist_union_cores_tt
+				if = { # Any Spanish Puppet will get annexed
+					limit = {
+						any_country = {
+							OR = {
+								original_tag = SPR
+								tag = GLC
+								tag = NAV
+								tag = CAT
+								tag = ADU
+							}
+							is_puppet_of = ROOT
+						}
+					}
+					hidden_effect = {
+						every_country = {
+							limit = {
+								OR = {
+									original_tag = SPR
+									tag = GLC
+									tag = NAV
+									tag = CAT
+									tag = ADU
+								}
+								is_puppet_of = ROOT
+							}
+							ROOT = {
+								annex_country = {
+								    target = PREV
+								    transfer_troops = yes
+								}
+							}
+						}
+					}
+				}
+				custom_effect_tooltip = POR_the_iberian_socialist_union_annex_puppets_tt
+				# Event for annexation sent to independent Spanish tags
+				every_country = {
+					limit = {
+						OR = {
+							tag = SPD
+							tag = GLC
+							tag = NAV
+							tag = CAT
+							tag = ADU
+						}
+						NOT = { has_war_with = ROOT }
+						NOT = { is_puppet_of = ROOT }
+					}
+					country_event = { id = lar_portugal_iberian_workers_united.2 hours = 6 }
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_the_popular_front_bloc
+		available = {
+			has_global_flag = scw_over
+			has_government = communism			
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_the_iberian_socialist_union }	
+		mutually_exclusive = { focus = POR_join_the_comintern }		
+		icon = GFX_focus_generic_diplomatic_treaty
+		x = 0		
+		y = 1
+
+		relative_position_id = POR_the_iberian_socialist_union
+		cost = 10
+		completion_reward = {
+			create_faction = POR_popular_front_bloc
+			every_other_country = {
+				limit = {
+					capital_scope = { is_on_continent = europe }
+					has_government = communism
+					is_in_faction = yes
+				}
+				add_opinion_modifier = {
+					target = POR
+					modifier = POR_iberian_communism
+				}
+			}
+			every_other_country = {
+				limit = {
+					capital_scope = { is_on_continent = europe }
+					has_government = communism
+					is_in_faction = no
+				}
+				add_opinion_modifier = {
+					target = POR
+					modifier = POR_iberian_communism
+				}
+				hidden_effect = { 
+					country_event = generic.5
+				}				
+				custom_effect_tooltip = POR_the_popular_front_bloc_tt
+			}
+			custom_effect_tooltip = POR_the_popular_front_bloc_explanatory_tt
+			every_other_country = {
+				limit = {
+					capital_scope = { is_on_continent = europe }
+					NOT = { has_government = communism }
+					communism > 0.19
+				}
+				add_timed_idea = {
+					idea = POR_iberian_communism_pressure
+					days = 730
+				}
+			}
+			# SPA Iberian Pact - either POR or SPA join a faction - the other must be added too.
+			if = {
+				limit = {
+					has_country_flag = SPA_iberian_pact
+				}
+				save_event_target_as = iberian_pact_invitee
+				every_other_country = {
+					limit = {
+						OR = {
+							original_tag = POR
+							original_tag = SPA
+						}
+						has_country_flag = SPA_iberian_pact
+						NOT = { is_in_faction_with = ROOT }
+						NOT = { is_in_faction = yes }
+					}
+					country_event = lar_spain.28
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_latin_american_communism
+		available = {
+			has_global_flag = scw_over
+			has_government = communism
+			OR = {
+				country_exists = BRA country_exists = MEX
+				country_exists = COL country_exists = ARG
+				country_exists = PRU country_exists = VEN
+				country_exists = CHL country_exists = GUA
+				country_exists = ECU country_exists = CUB
+				country_exists = BOL country_exists = HAI
+				country_exists = DOM country_exists = HON
+				country_exists = PAR country_exists = ELS
+				country_exists = NIC country_exists = COS
+				country_exists = PAN country_exists = URG
+			}				
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_the_popular_front_bloc }			
+		icon = GFX_focus_por_latin_american_communism
+		x = 0		
+		y = 1
+
+		relative_position_id = POR_the_popular_front_bloc
+		cost = 10
+		completion_reward = {
+			every_other_country = {
+				limit = {
+					OR = {
+						TAG = BRA TAG = MEX
+						TAG = COL TAG = ARG
+						TAG = PRU TAG = VEN
+						TAG = CHL TAG = GUA
+						TAG = ECU TAG = CUB
+						TAG = BOL TAG = HAI
+						TAG = DOM TAG = HON
+						TAG = PAR TAG = ELS
+						TAG = NIC TAG = COS
+						TAG = PAN TAG = URG
+					}
+					has_government = communism
+				}
+				add_opinion_modifier = {
+					target = POR
+					modifier = POR_iberian_communism
+				}
+			}
+			every_other_country = {
+				limit = {
+					OR = {
+						TAG = BRA TAG = MEX
+						TAG = COL TAG = ARG
+						TAG = PRU TAG = VEN
+						TAG = CHL TAG = GUA
+						TAG = ECU TAG = CUB
+						TAG = BOL TAG = HAI
+						TAG = DOM TAG = HON
+						TAG = PAR TAG = ELS
+						TAG = NIC TAG = COS
+						TAG = PAN TAG = URG
+					}
+					NOT = { has_government = communism }
+				}
+				add_popularity = {
+				    ideology = communism
+				    popularity = 0.05
+				}
+				add_timed_idea = {
+					idea = communist_influence
+					days = 730
+				}	
+			}
+			add_ideas = POR_spread_communism_overseas
+		}
+	}
+
+	focus = {
+		id = POR_our_comrades_overseas
+		available = {
+			has_global_flag = scw_over
+			has_government = communism
+			any_country = {
+				OR = {
+					TAG = BRA TAG = MEX
+					TAG = COL TAG = ARG
+					TAG = PRU TAG = VEN
+					TAG = CHL TAG = GUA
+					TAG = ECU TAG = CUB
+					TAG = BOL TAG = HAI
+					TAG = DOM TAG = HON
+					TAG = PAR TAG = ELS
+					TAG = NIC TAG = COS
+					TAG = PAN TAG = URG						
+				}
+				has_government = communism
+			}
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_latin_american_communism }			
+		icon = GFX_focus_hol_legacy_of_the_de_zeven_provincien_mutiny
+		x = 0		
+		y = 1
+
+		relative_position_id = POR_latin_american_communism
+		cost = 10
+		completion_reward = { 
+			every_other_country = {
+				limit = {
+					OR = {
+						TAG = BRA TAG = MEX
+						TAG = COL TAG = ARG
+						TAG = PRU TAG = VEN
+						TAG = CHL TAG = GUA
+						TAG = ECU TAG = CUB
+						TAG = BOL TAG = HAI
+						TAG = DOM TAG = HON
+						TAG = PAR TAG = ELS
+						TAG = NIC TAG = COS
+						TAG = PAN TAG = URG						
+					}
+					has_government = communism			
+				}
+				if = {
+					limit = { is_in_faction = no }
+					hidden_effect = { 
+						country_event = generic.5
+					}				
+					custom_effect_tooltip = POR_the_popular_front_bloc_tt
+				}
+			}
+			custom_effect_tooltip = POR_our_comrades_overseas_tt
+		}
+	}
+
+
+	focus = {
+		id = POR_visit_the_front
+		available = {
+			SPR_scw_in_progress = yes
+			if = {
+				limit = {
+					NOT = { has_global_flag = spanish_civil_war }
+				}
+				custom_trigger_tooltip = {
+				    tooltip = POR_spr_tooltip_country_exist_tt
+				    country_exists = SPR
+			    }
+			    custom_trigger_tooltip = {
+				    tooltip = POR_spr_tooltip_at_peace_tt
+					NOT = { has_war_with = SPR }
+			    }
+			}
+			else = {
+				country_exists = SPD
+				NOT = {has_war_with = SPD }
+			}
+		}
+
+		bypass = {
+			has_global_flag = scw_over
+		}
+		prerequisite = { focus = POR_support_the_spanish_republic }	
+		mutually_exclusive = { focus = POR_workers_of_iberia_unite}		
+		icon = GFX_focus_eng_special_air_service
+		x = 2		
+		y = 1
+
+		relative_position_id = POR_support_the_spanish_republic
+		cost = 10
+		search_filters = {FOCUS_FILTER_RESEARCH}
+		completion_reward = { 
+			add_tech_bonus = {
+				name = POR_visit_the_front
+			    bonus = 1.0
+			    uses = 1
+			    category = land_doctrine
+			}
+			add_tech_bonus = {
+				name = POR_visit_the_front
+			    bonus = 0.5
+			    uses = 1
+			    category = light_air
+			}
+			add_tech_bonus = {
+				name = POR_visit_the_front
+			    bonus = 0.5
+			    uses = 1
+			    category = cat_light_armor
+			}
+			army_experience = 20
+			air_experience = 10
+
+			hidden_effect = {
+				add_ai_strategy = {
+					type = befriend
+					id = SPD
+					value = 100
+				}
+				SPD = {
+					add_ai_strategy = {
+						type = befriend
+						id = ROOT
+						value = 100
+					}
+				}
+			}			
+		}
+	}				
+	
+	focus = {
+		id = POR_they_need_our_help
+
+		select_effect = {
+			if = {
+				limit = {
+					country_exists = SPA
+					is_neighbor_of = SPA
+				}
+				add_ai_strategy = {
+					type = prepare_for_war
+					id = SPA
+					value = 100
+				}
+			}
+			if = {
+				limit = {
+					country_exists = SPB
+					is_neighbor_of = SPB
+				}
+				add_ai_strategy = {
+					type = prepare_for_war
+					id = SPB
+					value = 100
+				}
+			}
+			if = {
+				limit = {
+					country_exists = SPC
+					is_neighbor_of = SPC
+				}
+				add_ai_strategy = {
+					type = prepare_for_war
+					id = SPC
+					value = 100
+				}
+			}
+		}
+
+		available = {
+			has_civil_war = no
+			SPR_scw_in_progress = yes
+			if = {
+				limit = {
+					NOT = { has_global_flag = spanish_civil_war }
+				}
+				custom_trigger_tooltip = {
+				    tooltip = POR_spr_tooltip_country_exist_tt
+				    country_exists = SPR
+			    }
+			    custom_trigger_tooltip = {
+				    tooltip = POR_spr_tooltip_at_peace_tt
+					NOT = { has_war_with = SPR }
+			    }
+			}
+			else = {
+				country_exists = SPD
+				NOT = {has_war_with = SPD }
+			}
+			has_government = communism
+			is_puppet = no
+		}
+
+		bypass = {
+			has_global_flag = scw_over
+		}
+		prerequisite = { focus = POR_visit_the_front }			
+		icon = GFX_focus_intervention_spain_republic
+		x = 0		
+		y = 2
+
+		relative_position_id = POR_visit_the_front
+		cost = 10
+		completion_reward = { 	
+			unlock_decision_tooltip = POR_fight_alongside_the_republic
+			if = { 
+				limit = { country_exists = SPA }
+				SPA = {
+					country_event = { id = lar_portugal_spanish_civil_war.1 }
+				}
+			}
+			if = { 
+				limit = { country_exists = SPB }
+				SPB = {
+					country_event = { id = lar_portugal_spanish_civil_war.1 }
+				}
+			}
+			if = { 
+				limit = { country_exists = SPC }
+				SPC = {
+					country_event = { id = lar_portugal_spanish_civil_war.1 }
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_intervention_in_spain
+
+		select_effect = {
+			every_country = {
+				limit = {
+					original_tag = SPR
+					NOT = { has_government = ROOT }
+					NOT = { is_in_faction_with = ROOT }
+				}
+				POR = {
+					add_ai_strategy = {
+						type = befriend
+						id = PREV
+						value = -100
+					}
+					add_ai_strategy = {
+						type = alliance
+						id = PREV
+						value = -100
+					}
+					add_ai_strategy = {
+						type = prepare_for_war
+						id = PREV
+						value = 100
+					}
+				}
+			}
+		}
+
+		available = {				
+			has_global_flag = scw_over
+			OR = {
+				has_government = democratic
+				has_government = communism
+			}
+			any_country = {
+				original_tag = SPR
+				NOT = { has_government = ROOT }
+				NOT = { is_in_faction_with = ROOT }
+			}
+		}
+
+		ai_will_do = {
+			factor = 1
+			modifier = {
+				factor = 0
+				has_completed_focus = POR_support_the_spanish_republic
+				NOT = { has_completed_focus = POR_join_the_comintern }
+			}
+			modifier = {
+				factor = 100
+				has_completed_focus = POR_join_the_comintern
+				SPD = { has_completed_focus = SPR_against_trotskyism_and_stalinism }
+			}
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_they_need_our_help focus = POR_allow_free_elections }			
+		icon = GFX_focus_focus_fra_intervention_spain
+		x = 0		
+		y = 1
+
+		relative_position_id = POR_they_need_our_help
+		cost = 10
+		completion_reward = {
+			hidden_effect = {
+				every_country = {
+					limit = {
+						original_tag = SPR
+						NOT = { has_government = ROOT }
+						NOT = { is_in_faction_with = ROOT }
+					}
+					POR = {
+						create_wargoal = {
+						  	target = PREV
+						    type = topple_government
+						}
+					}
+				}
+			}
+			custom_effect_tooltip = POR_intervention_in_spain_tt
+
+			hidden_effect = {
+				every_country = {
+					limit = {
+						original_tag = SPR
+						NOT = { has_government = ROOT }
+						NOT = { is_in_faction_with = ROOT }
+					}
+					POR = {
+						add_ai_strategy = {
+							type = declare_war
+							id = PREV
+							value = 100
+						}
+					}
+				}
+			}
+		}
+
+	}
+
+	focus = {
+		id = POR_securing_the_free_world
+		available = {			
+			has_global_flag = scw_over
+			threat > 0.4
+			has_government = democratic	
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_allow_free_elections }
+
+		icon = GFX_focus_generic_treaty
+		x = 2		
+		y = 1
+
+		relative_position_id = POR_they_need_our_help
+		cost = 10
+		completion_reward = {
+			hidden_effect = {
+				every_other_country = {
+					limit = {
+						capital_scope = {
+							is_on_continent = europe
+						}
+						OR = {
+							has_government = democratic
+							has_government = neutrality
+						}
+						is_major = no
+					}
+					POR = { 
+						give_guarantee = PREV 
+
+						add_ai_strategy = {
+							type = befriend
+							id = PREV
+							value = 100
+						}
+					}
+				}			
+			}
+			custom_effect_tooltip = portugal_guarantees_freedom_tt
+			set_rule = { can_create_factions = yes }
+		}
+	}
+
+	focus = {
+		id = POR_protect_chinese_civilians
+
+		select_effect = {
+			random_country = {
+				limit = { controls_state = 592 }
+				ROOT = {
+					add_ai_strategy = {
+						type = prepare_for_war
+						id = PREV
+						value = 100
+					}
+				}
+			}
+		}
+
+		available = {	
+			has_global_flag = scw_over	
+			592 = {
+				owner = { 
+					has_war = yes
+					NOT = { is_in_faction_with = ROOT } 
+				}
+			}
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_they_need_our_help focus = POR_allow_free_elections focus = POR_the_popular_front_bloc }			
+		icon = GFX_focus_chi_united_front
+		x = -2		
+		y = 1
+
+		relative_position_id = POR_they_need_our_help
+		cost = 10
+		completion_reward = { 
+			592 = {
+				owner =  {				
+					ROOT = {
+						create_wargoal = {
+						  	target = PREV
+						    type = annex_everything
+						}						
+					}
+				}				
+			}
+
+			hidden_effect = {
+				random_country = {
+					limit = { controls_state = 592 }
+					ROOT = {
+						add_ai_strategy = {
+							type = declare_war
+							id = PREV
+							value = 100
+						}
+					}
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_strict_neutrality_in_the_spanish_civil_war
+		available = {
+			SPR_scw_in_progress = yes			
+		}
+
+		bypass = {
+			has_global_flag = scw_over	
+		}
+		prerequisite = { focus = POR_popular_front focus = POR_estado_novo }
+		mutually_exclusive	= { focus = POR_support_the_spanish_republic focus = POR_support_the_spanish_nationalists focus = POR_a_royal_wedding }
+		icon = GFX_goal_generic_neutrality_focus
+		x = 5
+		y = 0
+
+		relative_position_id = POR_support_the_spanish_republic
+		cost = 10
+		completion_reward = { 	
+			every_other_country = {
+				add_opinion_modifier = {
+				    target = POR
+				    modifier = POR_neutrality_opinion_trade
+				}					
+			}
+			every_other_country = {
+				limit = {
+					has_government = democratic
+				}				 								
+				add_opinion_modifier = {
+				    target = POR
+				    modifier = POR_neutrality_opinion_democratic
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_british_investment_in_mines
+		available = {
+			NOT = { has_government = communism }
+			ENG = {
+				exists = yes
+				NOT = { has_war_with = ROOT }
+				has_civil_war = no
+				has_capitulated = no
+				owns_state = 126 #Owns London
+			}	
+		}
+
+		bypass = {
+			NOT = { country_exists = ENG }	
+		}
+		prerequisite = { focus = POR_strict_neutrality_in_the_spanish_civil_war }	
+		icon = GFX_goal_generic_construct_civilian
+		x = -1		
+		y = 1
+
+		relative_position_id = POR_strict_neutrality_in_the_spanish_civil_war
+		cost = 10
+		search_filters = {FOCUS_FILTER_INDUSTRY FOCUS_FILTER_RESEARCH FOCUS_FILTER_POLITICAL}
+		completion_reward = {
+			if = {
+				limit = { has_full_control_of_state = 112 }
+				add_resource = {
+				    type = tungsten
+				    amount = 50
+				    state = 112 #Lisbon
+				}
+			}
+			add_tech_bonus = {
+				name = POR_british_investment_in_mines
+			    bonus = 1.0
+			    uses = 2
+			    category = industry
+			}
+			add_timed_idea = {
+				idea = POR_british_influence
+				days = 1460
+			}
+
+			hidden_effect = {
+				add_ai_strategy = {
+					type = befriend
+					id = ENG
+					value = 50
+				}
+				ENG = {
+					add_ai_strategy = {
+						type = befriend
+						id = ROOT
+						value = 50
+					}
+				}
+			}	
+		}
+	}
+
+	focus = {
+		id = POR_british_guns
+		available = {			
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_strict_neutrality_in_the_spanish_civil_war }	
+		icon = GFX_goal_generic_military_sphere
+		x = 1		
+		y = 1
+
+		relative_position_id = POR_strict_neutrality_in_the_spanish_civil_war
+		cost = 10
+		completion_reward = { 
+			unlock_decision_tooltip = POR_buy_aa_in_britain	
+			unlock_decision_tooltip = POR_buy_at_in_britain
+		}
+	}
+
+	focus = {
+		id = POR_british_industrial_investments
+		available = {
+			has_capitulated = no
+			ENG = {
+				exists = yes
+				NOT = { has_war_with = ROOT }
+				has_civil_war = no
+				has_capitulated = no
+				owns_state = 126 #Owns London
+			}
+		}
+
+		bypass = {
+			NOT = { country_exists = ENG }	
+		}
+		prerequisite = { focus = POR_british_investment_in_mines focus = POR_british_guns} 
+		icon = GFX_focus_generic_industry_3
+		x = 1		
+		y = 1
+
+		relative_position_id = POR_british_investment_in_mines
+		cost = 10
+		search_filters = {FOCUS_FILTER_INDUSTRY}
+		completion_reward = {
+			if = {
+				limit = { has_full_control_of_state = 112 }
+				112 = { #Lisbon
+					add_extra_state_shared_building_slots = 1
+					add_building_construction = {
+						type = industrial_complex		
+						level = 1
+						instant_build = yes
+					}
+				}
+			}
+			if = {
+				limit = { has_full_control_of_state = 180 }
+				180 = { #Porto
+					add_extra_state_shared_building_slots = 1
+					add_building_construction = {
+						type = industrial_complex		
+						level = 1
+						instant_build = yes
+					}			
+				}
+			}
+			if = {
+				limit = { has_full_control_of_state = 181 }
+				181 = { #Guarda
+					add_extra_state_shared_building_slots = 1
+					add_building_construction = {
+						type = industrial_complex		
+						level = 1
+						instant_build = yes
+					}			
+				}
+			}
+			if = {
+				limit = { has_full_control_of_state = 179 }
+				179 = { #Beja
+					add_extra_state_shared_building_slots = 1
+					add_building_construction = {
+						type = industrial_complex		
+						level = 1
+						instant_build = yes
+					}
+				}
+			}
+			if = {
+				limit = {has_completed_focus = POR_estado_novo}
+				remove_ideas = POR_estado_novo
+			}
+
+			hidden_effect = {
+				add_ai_strategy = {
+					type = befriend
+					id = ENG
+					value = 100
+				}
+				ENG = {
+					add_ai_strategy = {
+						type = befriend
+						id = ROOT
+						value = 100
+					}
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_allow_free_elections
+		available = {
+			democratic > 0.5
+			has_war = no
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_british_industrial_investments }	
+		icon = GFX_goal_support_democracy
+		x = 0		
+		y = 1
+
+		relative_position_id = POR_british_industrial_investments
+		cost = 10
+		search_filters = {FOCUS_FILTER_POLITICAL FOCUS_FILTER_STABILITY FOCUS_FILTER_INDUSTRY FOCUS_FILTER_STABILITY}
+		completion_reward = {
+			every_other_country = {
+				limit = {
+					has_government = democratic
+				}
+					 								
+				add_opinion_modifier = {
+				    target = POR
+				    modifier = POR_election_opinion_democratic
+				}
+			}
+			remove_ideas = POR_unstable_republic
+			if = {
+				limit = {
+					has_idea = internationalism
+				}
+				remove_ideas = internationalism
+			}
+			custom_effect_tooltip = available_political_advisor
+			show_ideas_tooltip = POR_jaime_cortesao
+			custom_effect_tooltip = available_theorist
+			show_ideas_tooltip = POR_jose_manuel_sarmento_de_beires
+			if = {
+				limit = {
+					has_completed_focus = POR_limited_self_rule
+				}
+				custom_effect_tooltip = available_political_advisor
+				show_ideas_tooltip = POR_francisco_da_cunha_leal
+			}
+			create_corps_commander = {
+				name = "José Mendes dos Reis"
+				portrait_path = "gfx/leaders/Europe/Portrait_Europe_Generic_land_4.dds"
+				traits = { war_hero infantry_officer }
+				skill = 3
+				attack_skill = 3
+				defense_skill = 2
+				planning_skill = 3
+				logistics_skill = 3
+			}
+			create_navy_leader = {
+				name = "Armando Pereira de Castro Agatão Lança"
+				portrait_path = "gfx/leaders/Europe/Portrait_Europe_Generic_navy_1.dds"
+				traits = { spotter bold }
+				skill = 3
+				attack_skill = 2
+				defense_skill = 4
+				maneuvering_skill = 3
+				coordination_skill = 2
+			}
+			if = {
+				limit = {
+					NOT = { has_government = democratic }
+				}
+				set_politics = {
+					ruling_party = democratic
+					elections_allowed = yes
+				}
+
+				if = { #Low Stability triggers a Civil War
+					limit = {
+						has_stability < 0.4
+					}
+					set_temp_variable = { POR_democratic_cw_opposition = party_popularity@neutrality }
+					multiply_temp_variable = { POR_democratic_cw_opposition = 0.6 }
+					add_to_temp_variable = { POR_democratic_cw_opposition = party_popularity@fascism }
+					start_civil_war = {	
+						ideology = fascism
+						size = POR_democratic_cw_opposition
+						capital = 180
+						states = { 181 }
+					}
+				}
+				else = {
+					add_stability = -0.1
+				}
+				custom_effect_tooltip = POR_potential_civil_war_low_requirement_tt
+			}
+			else = {
+				add_political_power = 120
+				add_popularity = {
+				    ideology = democratic
+				    popularity = 0.05
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_join_the_allies
+		available = {
+			is_in_faction = no
+			any_other_country = {
+				NOT = { has_war_with = ROOT }
+				is_faction_leader = yes
+				is_major = yes
+				has_government = democratic
+			}
+			NOT = {
+				any_other_country = {
+					is_in_faction_with = ENG
+					has_war_with = POR
+				}
+			}			
+		}
+
+		bypass = {	
+			OR = {
+				is_in_faction_with = ENG
+				AND = {
+					is_in_faction = yes
+					any_other_country = {
+						is_faction_leader = yes
+						is_in_faction_with = ROOT
+						has_government = democratic
+					}
+				}
+			}	
+		}
+		prerequisite = { focus = POR_allow_free_elections }	
+		icon = GFX_focus_chi_british_cooperation
+		x = 0		
+		y = 2
+
+		relative_position_id = POR_allow_free_elections
+		cost = 10
+		completion_reward = { 	
+			if = {
+				limit = { 
+					ENG = {
+						is_faction_leader = yes
+						has_government = democratic
+						not = { has_war_with = ROOT }
+					}
+				}
+				ENG = { country_event = { id = generic.2 hours = 4 } }
+			}
+			else = {
+				get_best_alliance_match_democratic_effect = yes
+				var:best_leader = {
+					country_event = { id = generic.2 hours = 4 }
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_research_sharing
+		available = {	
+			is_in_faction_with = ENG		
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_join_the_allies focus = POR_honor_anglo_portuguese_alliance }	
+		icon = GFX_focus_research2
+		x = 2		
+		y = 1
+
+		relative_position_id = POR_join_the_allies
+		cost = 10
+		search_filters = {FOCUS_FILTER_RESEARCH}
+		completion_reward = { 
+			ENG = { add_to_tech_sharing_group = commonwealth_research }
+			add_to_tech_sharing_group = commonwealth_research
+		}
+	}
+
+	focus = {
+		id = POR_oppose_germany
+
+		will_lead_to_war_with = GER
+
+		select_effect = {
+			add_ai_strategy = {
+				type = prepare_for_war
+				id = GER
+				value = 100
+			}
+		}
+
+		available = {
+			country_exists = GER
+			GER = {
+				has_government = fascism
+				has_capitulated = no
+			}		
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_join_the_allies focus = POR_honor_anglo_portuguese_alliance }	
+		icon = GFX_focus_ger_oppose_hitler
+		x = 4		
+		y = 1
+
+		relative_position_id = POR_join_the_allies
+		cost = 10
+		completion_reward = { 	
+			create_wargoal = {
+				target = GER
+				type = topple_government
+				expire = 0
+			}	
+
+			hidden_effect = {
+				add_ai_strategy = {
+					type = declare_war
+					id = GER
+					value = 100
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_iberian_summit
+		available = {
+			has_global_flag = scw_over
+			has_war = no
+			is_in_faction = no
+			NOT = { has_government = communism }
+			OR = {
+				if = {
+					limit = {
+						NOT = { has_global_flag = spanish_civil_war }
+					}
+					custom_trigger_tooltip = {
+					    tooltip = POR_spr_tooltip_country_exist_tt
+					    country_exists = SPR
+				    }
+				    custom_trigger_tooltip = {
+					    tooltip = POR_spr_tooltip_at_peace_tt
+						NOT = { has_war_with = SPR }
+				    }
+				    SPR = {
+				 	   has_completed_focus = SPR_maintain_the_second_republic
+				    	has_government = democratic
+				    }
+				}
+				else = {
+					AND = {
+						country_exists = SPD
+						SPD = {
+							has_war = no 
+							is_in_faction = no
+							has_completed_focus = SPR_maintain_the_second_republic
+							has_government = democratic
+						}
+					}
+				}				
+				AND = {
+					country_exists = SPA
+					SPA = {
+						has_war = no 
+						is_in_faction = no
+						OR = {
+							has_completed_focus = SPA_the_phalanx_ascendant
+							AND = {
+								has_completed_focus = SPA_unify_the_nationalist_front
+								NOT = { has_completed_focus = SPA_the_iberian_pact }
+							}
+						}
+					}
+				}				
+			}	
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_allow_free_elections focus = POR_send_assistance }	
+
+		mutually_exclusive = { focus = POR_nationalist_intervention }
+
+		icon = GFX_focus_por_iberian_summit
+		x = 1		
+		y = 1
+
+		relative_position_id = POR_allow_free_elections
+		cost = 10
+		completion_reward = { 
+			unlock_decision_tooltip = POR_iberian_summit_pro_axis
+			unlock_decision_tooltip = POR_iberian_summit_pro_allies
+		}
+	}
+
+	focus = {
+		id = POR_estado_novo
+		available = {			
+		}
+
+		bypass = {		
+		}
+		mutually_exclusive = { focus = POR_popular_front}
+		prerequisite = {
+		}
+		icon = GFX_focus_por_estado_novo
+		x = 12
+		y = 0
+
+		relative_position_id = POR_popular_front
+		cost = 10
+		search_filters = {FOCUS_FILTER_INDUSTRY FOCUS_FILTER_POLITICAL}
+		completion_reward = { 	
+			add_ideas = POR_estado_novo
+			add_political_power = 100
+			custom_effect_tooltip = available_chief_of_army
+			show_ideas_tooltip = POR_julio_botelho_moniz
+			custom_effect_tooltip = remove_political_advisor
+			show_ideas_tooltip = POR_alvaro_cunhal
+		}
+	}
+
+	focus = {
+		id = POR_support_the_spanish_nationalists
+		available = {	
+			SPR_scw_in_progress = yes
+			country_exists = SPA
+			NOT = { has_war_with = SPA }
+		}
+
+		bypass = {
+			has_global_flag = scw_over	
+		}
+		prerequisite = { focus = POR_estado_novo }
+		mutually_exclusive = { focus = POR_strict_neutrality_in_the_spanish_civil_war focus = POR_support_the_spanish_republic focus = POR_a_royal_wedding }
+		icon = GFX_goal_support_fascism
+		x = 0	
+		y = 1
+
+		relative_position_id = POR_estado_novo
+		cost = 10
+		completion_reward = { 	
+			SPA = {
+				add_opinion_modifier = {
+				    target = POR
+				    modifier = POR_helped_in_civil_war
+				}
+				add_manpower = 10000
+			}			
+			add_ideas = POR_volunteers_in_the_war_nationalist
+			add_manpower = -10000
+			hidden_effect = {
+				add_equipment_to_stockpile = {
+					type = infantry_equipment
+					amount = 2000
+				}
+			}
+			send_equipment = {
+			    equipment = infantry_equipment
+			    amount = 2000
+			    target = SPA
+			}
+			set_rule = { can_send_volunteers = yes }
+		}
+	}
+
+	focus = {
+		id = POR_portuguese_legion
+		available = {
+			SPR_scw_in_progress = yes				
+		}
+
+		bypass = {
+			has_global_flag = scw_over
+		}
+		prerequisite = { focus = POR_support_the_spanish_nationalists }
+		icon = GFX_focus_por_portuguese_legion
+		x = 0		
+		y = 1
+
+		relative_position_id = POR_support_the_spanish_nationalists
+		cost = 10
+		search_filters = {FOCUS_FILTER_MANPOWER}
+		completion_reward = {
+			add_ideas = por_portuguese_legion
+		}
+	}
+
+	focus = {
+		id = POR_observation_mission
+
+		available = {	
+			SPR_scw_in_progress = yes
+			country_exists = SPA	
+			NOT = { has_war_with = SPA }	
+		}
+
+		bypass = {
+			has_global_flag = scw_over
+		}
+		prerequisite = { focus = POR_portuguese_legion }
+		icon = GFX_goal_generic_position_armies
+		x = -4		
+		y = 1
+
+		relative_position_id = POR_portuguese_legion
+		cost = 10
+		search_filters = {FOCUS_FILTER_RESEARCH}
+		completion_reward = { 	
+			add_tech_bonus = {
+				name = POR_observation_mission
+			    bonus = 1.0
+			    uses = 1
+			    category = air_doctrine
+			}
+			add_tech_bonus = {
+				name = POR_observation_mission
+			    bonus = 0.5
+			    uses = 1
+			    category = light_air
+			}
+			add_tech_bonus = {
+				name = POR_observation_mission
+			    bonus = 0.5
+			    uses = 1
+			    category = cat_light_armor
+			}
+			army_experience = 10
+			air_experience = 20
+
+			hidden_effect = {
+				add_ai_strategy = {
+					type = befriend
+					id = SPA
+					value = 100
+				}
+				SPA = {
+					add_ai_strategy = {
+						type = befriend
+						id = POR
+						value = 100
+					}
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_send_assistance
+
+		select_effect = {
+			if = {
+				limit = {
+					country_exists = SPD
+					is_neighbor_of = SPD
+				}
+				add_ai_strategy = {
+					type = prepare_for_war
+					id = SPD
+					value = 100
+				}
+			}
+			if = {
+				limit = {
+					country_exists = SPB
+					is_neighbor_of = SPB
+				}
+				add_ai_strategy = {
+					type = prepare_for_war
+					id = SPB
+					value = 100
+				}
+			}
+			if = {
+				limit = {
+					country_exists = SPC
+					is_neighbor_of = SPC
+				}
+				add_ai_strategy = {
+					type = prepare_for_war
+					id = SPC
+					value = 100
+				}
+			}
+		}
+
+		available = {
+			has_civil_war = no
+			SPR_scw_in_progress = yes
+			country_exists = SPA
+			NOT = { has_war_with = SPA }
+			is_puppet = no
+		}
+
+		bypass = {
+			has_global_flag = scw_over
+		}
+		prerequisite = { focus = POR_observation_mission }
+		icon = GFX_focus_intervention_spain_nationalists
+		x = 0	
+		y = 1
+
+		relative_position_id = POR_observation_mission
+		cost = 10
+		completion_reward = { 	
+			unlock_decision_tooltip = POR_fight_alongside_the_nationalists
+			if = { 
+				limit = { country_exists = SPD }
+				SPD = {
+					country_event = { id = lar_portugal_spanish_civil_war.2 }
+				}
+			}
+			if = { 
+				limit = { country_exists = SPB }
+				SPB = {
+					country_event = { id = lar_portugal_spanish_civil_war.2 }
+				}
+			}
+			if = { 
+				limit = { country_exists = SPC }
+				SPC = {
+					country_event = { id = lar_portugal_spanish_civil_war.2 }
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_nationalist_intervention
+
+		select_effect = {
+			every_country = {
+				limit = {
+					original_tag = SPR
+					NOT = { has_government = ROOT }
+					NOT = { is_in_faction_with = ROOT }
+				}
+				POR = {
+					add_ai_strategy = {
+						type = befriend
+						id = PREV
+						value = -100
+					}
+					add_ai_strategy = {
+						type = alliance
+						id = PREV
+						value = -100
+					}
+					add_ai_strategy = {
+						type = prepare_for_war
+						id = PREV
+						value = 100
+					}
+				}
+			}
+		}
+
+		available = {	
+			has_global_flag = scw_over
+			any_country = {
+				original_tag = SPR
+				NOT = { has_government = ROOT }
+				NOT = { is_in_faction_with = ROOT }
+			}
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_send_assistance}
+
+		mutually_exclusive = { focus = POR_iberian_summit }
+
+		icon = GFX_goal_generic_major_war
+		x = 0	
+		y = 1
+
+		relative_position_id = POR_send_assistance
+		cost = 10
+		completion_reward = { 	
+			hidden_effect = {
+				every_country = {
+					limit = {
+						original_tag = SPR
+						NOT = { has_government = ROOT }
+						NOT = { is_in_faction_with = ROOT }
+					}
+					POR = {
+						create_wargoal = {
+						  	target = PREV
+						    type = topple_government
+						}
+					}
+				}
+			}
+			custom_effect_tooltip = POR_nationalist_intervention_tt
+
+			hidden_effect = {
+				every_country = {
+					limit = {
+						original_tag = SPR
+						NOT = { has_government = ROOT }
+						NOT = { is_in_faction_with = ROOT }
+					}
+					POR = {
+						add_ai_strategy = {
+							type = declare_war
+							id = PREV
+							value = 100
+						}
+					}
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_strengthen_the_regime
+		available = {
+			has_country_leader = { name = "António de Oliveira Salazar" }
+			has_manpower > 80000
+			has_equipment = { support_equipment > 799 }
+			has_equipment = { infantry_equipment > 799 }
+		}
+
+		bypass = {	
+		}
+		prerequisite = { focus = POR_portuguese_legion }
+
+		mutually_exclusive = { focus = POR_national_syndicalism }
+
+		icon = GFX_goal_generic_political_pressure
+		x = 4
+		y = 0
+
+		relative_position_id = POR_observation_mission
+		cost = 10
+		search_filters = {FOCUS_FILTER_POLITICAL FOCUS_FILTER_INDUSTRY}
+		completion_reward = { 
+			add_manpower = -3000
+			add_equipment_to_stockpile = {
+				type = support_equipment
+				amount = -800
+				producer = POR
+			}
+			add_equipment_to_stockpile = {
+				type = infantry_equipment
+				amount = -800
+				producer = POR
+			}
+			add_stability = -0.1
+			add_popularity = {
+			    ideology = neutrality
+				popularity = 0.10
+			}
+			swap_ideas = {
+				remove_idea = POR_estado_novo
+				add_idea = POR_estado_novo_2	
+			}
+			custom_effect_tooltip = remove_chief_of_army
+			show_ideas_tooltip = POR_rolao_preto
+		}
+	}
+
+	focus = {
+		id = POR_the_capital_of_espionage
+		available = {	
+			owns_state = 112
+			has_war = no
+			OR = {
+				AND = {
+					ENG = { 
+						exists = yes
+						NOT = { has_war_with = ROOT }
+					}
+					any_country = {
+						is_major = yes
+						has_war_with = ENG
+					}
+				}
+				AND = {
+					GER = { 
+						exists = yes
+						NOT = { has_war_with = ROOT }
+					}
+					any_country = {
+						is_major = yes
+						has_war_with = GER
+					}
+				}
+			}
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_strengthen_the_regime }
+
+		icon = GFX_goal_generic_intelligence_exchange
+		x = -2
+		y = 1
+
+		relative_position_id = POR_strengthen_the_regime
+		cost = 10
+		completion_reward = { 
+			add_ideas = POR_the_capital_of_espionage
+		}
+	}
+
+	focus = {
+		id = POR_appease_monarchists
+		available = {	
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_strengthen_the_regime }	
+		icon = GFX_goal_tfv_strengthen_commonwealth_ties
+		x = 0
+		y = 1
+
+		relative_position_id = POR_strengthen_the_regime
+		cost = 10
+		search_filters = {FOCUS_FILTER_POLITICAL FOCUS_FILTER_STABILITY FOCUS_FILTER_INDUSTRY}
+		completion_reward = { 
+			add_political_power = 70
+			add_popularity = {
+			    ideology = neutrality
+				popularity = 0.05
+			}
+			swap_ideas = {
+				remove_idea = POR_estado_novo_2
+				add_idea = POR_estado_novo_3	
+			}
+			custom_effect_tooltip = available_political_advisor
+			show_ideas_tooltip = POR_joao_de_azevedo_coutinho
+			show_ideas_tooltip = POR_joao_francisco_de_barbosa_azevedo
+		}
+	}
+
+	focus = {
+		id = POR_concordat_with_the_holy_see
+		available = {
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_appease_monarchists }	
+		icon = GFX_focus_por_concordat
+		x = -1
+		y = 1
+
+		relative_position_id = POR_appease_monarchists
+		cost = 10
+		search_filters = {FOCUS_FILTER_POLITICAL FOCUS_FILTER_STABILITY}
+		completion_reward = { 
+			add_political_power = 120
+			swap_ideas = {
+				remove_idea = POR_estado_novo_3
+				add_idea = POR_estado_novo_4	
+			}
+			custom_effect_tooltip = available_political_advisor
+			show_ideas_tooltip = POR_manuel_goncalves_cerejeira
+		}
+	}
+
+	focus = {
+		id = POR_honor_anglo_portuguese_alliance
+		available = {
+			is_in_faction = no
+			has_war = no
+			ENG = { 
+				exists = yes
+				NOT = {
+					has_war_with = ROOT 
+					any_other_country = {
+						is_in_faction_with = ENG
+						has_war_with = ROOT
+					}
+				}
+			}
+			any_country = {
+				is_major = yes
+				has_war_with = ENG
+			}
+		}
+
+		bypass = {		
+		}
+
+		
+		prerequisite = { focus = POR_concordat_with_the_holy_see }
+
+		mutually_exclusive = { focus = POR_proudly_alone }
+
+		icon = GFX_goal_generic_alliance
+		x = -1
+		y = 1
+
+		relative_position_id = POR_concordat_with_the_holy_see
+		cost = 10
+		completion_reward = { 
+			remove_ideas = POR_national_gold_reserves
+			remove_ideas = POR_unstable_republic
+			if = {
+				limit = { 
+					ENG = {
+						is_faction_leader = yes
+						has_government = democratic
+						NOT = { has_war_with = ROOT }
+					}
+				}
+				ENG = { country_event = { id = generic.2 hours = 4 } }
+			}
+			else = {
+				get_best_alliance_match_democratic_effect = yes
+				var:best_leader = {
+					country_event = { id = generic.2 hours = 4 }
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_national_gold_reserves
+		available = {
+			has_war = no
+			OR = {
+				AND = {
+					ENG = { 
+						exists = yes
+						NOT = { has_war_with = ROOT }
+					}
+					any_country = {
+						is_major = yes
+						has_war_with = ENG
+					}
+				}
+				AND = {
+					GER = { 
+						exists = yes
+						NOT = { has_war_with = ROOT }
+					}
+					any_country = {
+						is_major = yes
+						has_war_with = GER
+					}
+				}
+			}
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_appease_monarchists }	
+		icon = GFX_focus_usa_reestablish_the_gold_standard
+		x = 1
+		y = 1
+
+		relative_position_id = POR_appease_monarchists
+		cost = 10
+		search_filters = {FOCUS_FILTER_INDUSTRY}
+		completion_reward = { 
+			add_ideas = POR_national_gold_reserves
+			ENG = {
+				add_opinion_modifier = {
+					target = POR
+					modifier = POR_portuguese_trade
+				}
+			}
+			GER = {
+				add_opinion_modifier = {
+					target = POR
+					modifier = POR_portuguese_trade
+				}
+			}
+			every_other_country = {
+				limit = {
+					NOT = { tag = GER }
+					NOT = { tag = ENG }
+					OR = {
+						is_in_faction_with = ENG
+						is_in_faction_with = GER
+					}
+				}
+				add_opinion_modifier = {
+					target = POR
+					modifier = POR_portuguese_trade_minor
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_proudly_alone
+		available = {	
+			has_government = neutrality
+			has_war = no
+		}
+
+		bypass = {		
+		}
+		
+		prerequisite = { focus = POR_national_gold_reserves }
+		prerequisite = { focus = POR_concordat_with_the_holy_see }
+
+		mutually_exclusive = { focus = POR_honor_anglo_portuguese_alliance }
+
+		icon = GFX_focus_por_salazar
+		x = 2
+		y = 1
+
+		relative_position_id = POR_concordat_with_the_holy_see
+		cost = 10
+		search_filters = {FOCUS_FILTER_POLITICAL FOCUS_FILTER_WAR_SUPPORT FOCUS_FILTER_INDUSTRY}
+		completion_reward = { 
+			swap_ideas = {
+				remove_idea = POR_estado_novo_4
+				add_idea = POR_estado_novo_5	
+			}
+			remove_ideas = POR_unstable_republic
+		}
+	}
+
+	focus = {
+		id = POR_the_eastern_menace
+
+		will_lead_to_war_with = JAP
+
+		select_effect = {
+			add_ai_strategy = {
+				type = prepare_for_war
+				id = JAP
+				value = 100
+			}
+		}
+
+		available = {
+			JAP = {
+				exists = yes
+				NOT = { has_war_with = ROOT }
+			}
+		}
+
+		bypass = {		
+		}
+		
+		prerequisite = { focus = POR_proudly_alone }
+
+		icon = GFX_focus_AST_war_japan
+		x = -1
+		y = 1
+
+		relative_position_id = POR_proudly_alone
+		cost = 10
+		completion_reward = { 
+			create_wargoal = {
+				target = JAP
+				type = puppet_wargoal_focus
+				expire = 0
+			}
+
+			hidden_effect = {
+				add_ai_strategy = {
+					type = declare_war
+					id = JAP
+					value = 100
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_national_syndicalism
+		available = {			
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_portuguese_legion }
+
+		mutually_exclusive = { focus = POR_strengthen_the_regime }
+
+		icon = GFX_focus_generic_strike_at_democracy2
+		x = 8	
+		y = 0
+
+		relative_position_id = POR_observation_mission
+		cost = 10
+		search_filters = {FOCUS_FILTER_WAR_SUPPORT FOCUS_FILTER_POLITICAL FOCUS_FILTER_STABILITY}
+		completion_reward = {
+			add_stability = -0.2
+			add_war_support = 0.1
+			add_ideas = POR_national_syndicalism
+			custom_effect_tooltip = available_political_advisor
+			show_ideas_tooltip = POR_jose_hipolito_raposo_2
+			show_ideas_tooltip = POR_alberto_monsaraz
+		}
+	}
+
+	focus = {
+		id = POR_ditadura_militar
+		available = {	
+			fascism > 0.4
+			has_war = no
+		}
+
+		bypass = {		
+		}
+
+		prerequisite = { focus = POR_national_syndicalism }	
+		icon = GFX_goal_generic_forceful_treaty
+		x = 0
+		y = 1
+
+		relative_position_id = POR_national_syndicalism
+		cost = 10
+		search_filters = {FOCUS_FILTER_POLITICAL}
+		completion_reward = {
+			remove_ideas = POR_estado_novo
+			every_country = {
+				limit = { 
+					has_government = fascism
+					is_major = yes
+					capital_scope = {
+						is_on_continent = europe
+					}
+				}
+				add_opinion_modifier = {
+				    target = POR
+				    modifier = fascism_leanings_good
+				}
+			}
+			if = {
+				limit = {
+					NOT = { has_government = fascism }
+				}
+				set_politics = {
+					ruling_party = fascism
+				}	
+				
+				if = { #Low Stability triggers a Civil War
+					limit = {
+						has_stability < 0.6
+					}
+					set_temp_variable = { POR_fascist_cw_opposition = party_popularity@neutrality }
+					multiply_temp_variable = { POR_fascist_cw_opposition = 0.6 }
+					add_to_temp_variable = { POR_fascist_cw_opposition = party_popularity@democratic }
+					add_to_temp_variable = { POR_fascist_cw_opposition = party_popularity@communism }
+					start_civil_war = {	
+						ideology = neutrality
+						size = POR_fascist_cw_opposition
+						capital = 180
+						states = { 181 }
+					}
+				}
+				else = {
+					add_stability = -0.2
+				}
+				custom_effect_tooltip = POR_potential_civil_war_high_requirement_tt
+			}
+			else = {
+				add_political_power = 120
+				add_popularity = {
+				    ideology = fascism
+				    popularity = 0.05
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_camisas_azuis
+		available = {
+			has_government = fascism			
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_ditadura_militar }
+		icon = GFX_focus_generic_military_mission
+		x = 0		
+		y = 1
+
+		relative_position_id = POR_ditadura_militar
+		cost = 10
+		search_filters = {FOCUS_FILTER_WAR_SUPPORT}
+		completion_reward = { 
+			add_ideas = POR_camisas_azuis
+		}
+	}
+
+	focus = {
+		id = POR_join_the_axis
+		available = {
+			is_in_faction = no
+			has_government = fascism	
+			GER	= { 
+				exists = yes
+				is_faction_leader = yes 
+				has_capitulated = no
+				NOT = { has_war_with = ROOT }
+			}
+			NOT = {
+				any_other_country = {
+					is_in_faction_with = GER
+					has_war_with = ROOT
+				}
+			}	
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_camisas_azuis }
+		mutually_exclusive = { focus = POR_the_fifth_empire }
+		icon = GFX_focus_chi_mission_to_germany
+		x = -1		
+		y = 1
+
+		relative_position_id = POR_camisas_azuis
+		cost = 10
+		completion_reward = { 	
+			GER = {
+				country_event = { id = generic.2 hours = 4 }
+			}
+			remove_ideas = POR_unstable_republic
+		}
+	}
+
+	focus = {
+		id = POR_research_agreements
+		available = {
+			is_in_faction_with = GER			
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_join_the_axis }			
+		icon = GFX_goal_generic_scientific_exchange
+		x = -1		
+		y = 1
+
+		relative_position_id = POR_join_the_axis
+		cost = 10
+		search_filters = {FOCUS_FILTER_RESEARCH}
+		completion_reward = {
+			GER = { add_to_tech_sharing_group = axis_research }
+			add_to_tech_sharing_group = axis_research
+		}
+	}
+
+	focus = {
+		id = POR_the_fifth_empire
+		available = {	
+			has_government = fascism		
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_camisas_azuis }
+		mutually_exclusive = { focus = POR_join_the_axis }
+		icon = GFX_focus_por_the_fifth_empire
+		x = 1		
+		y = 1
+
+		relative_position_id = POR_camisas_azuis
+		cost = 10
+		search_filters = {FOCUS_FILTER_MANPOWER FOCUS_FILTER_WAR_SUPPORT FOCUS_FILTER_POLITICAL FOCUS_FILTER_STABILITY FOCUS_FILTER_INDUSTRY}
+		completion_reward = { 	
+			add_ideas = POR_the_fifth_empire
+			remove_ideas = POR_unstable_republic
+			if = {
+				limit = { is_in_faction = yes }
+				leave_faction = yes
+			}
+			set_rule = { can_create_factions = yes }
+			set_rule = { can_join_factions = no }
+			every_other_country = {
+				limit = {
+					NOT = { is_puppet_of = ROOT }
+				}
+				add_opinion_modifier = {
+					target = ROOT
+					modifier = POR_the_fifth_empire_has_threatening_ambitions
+				}
+				add_opinion_modifier = {
+					target = ROOT
+					modifier = embargo
+				}
+			}
+			set_cosmetic_tag = POR_empire
+		}
+	}
+
+	focus = {
+		id = POR_expand_the_chinese_territories
+
+		select_effect = {
+			every_country = {
+				limit = {
+					OR = {
+						controls_state = 592
+						controls_state = 594
+						controls_state = 325
+						controls_state = 613
+						controls_state = 622
+						controls_state = 604
+						controls_state = 615
+						controls_state = 611
+						controls_state = 328
+					}
+				}
+				ROOT = {
+					add_ai_strategy = {
+						type = prepare_for_war
+						id = PREV
+						value = 100
+					}
+				}
+			}
+		}
+
+		available = {		
+			owns_state = 729
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_join_the_axis focus = POR_the_fifth_empire }			
+		icon = GFX_focus_usa_focus_on_asia
+		x = -1	
+		y = 1
+
+		relative_position_id = POR_the_fifth_empire
+		cost = 10
+		completion_reward = {
+			hidden_effect = {
+				592 = {
+					owner =  {
+						ROOT = {
+							create_wargoal = {
+							  	target = PREV
+							    type = annex_everything
+							}						
+						}
+					}				
+				}
+
+				594 = {
+					owner =  {
+						ROOT = {
+							if = {
+								limit = {
+									NOT = { has_wargoal_against = PREV }
+								}
+								create_wargoal = {
+								  	target = PREV
+								    type = annex_everything
+								}	
+							}					
+						}
+					}				
+				}
+
+				325 = {
+					owner =  {
+						ROOT = {
+							if = {
+								limit = {
+									NOT = { has_wargoal_against = PREV }
+								}
+								create_wargoal = {
+								  	target = PREV
+								    type = annex_everything
+								}	
+							}					
+						}
+					}				
+				}
+
+				613 = {
+					owner =  {
+						ROOT = {
+							if = {
+								limit = {
+									NOT = { has_wargoal_against = PREV }
+								}
+								create_wargoal = {
+								  	target = PREV
+								    type = annex_everything
+								}	
+							}					
+						}
+					}				
+				}
+
+				622 = {
+					owner =  {
+						ROOT = {
+							if = {
+								limit = {
+									NOT = { has_wargoal_against = PREV }
+								}
+								create_wargoal = {
+								  	target = PREV
+								    type = annex_everything
+								}
+							}						
+						}
+					}				
+				}
+
+				604 = {
+					owner =  {
+						ROOT = {
+							if = {
+								limit = {
+									NOT = { has_wargoal_against = PREV }
+								}
+								create_wargoal = {
+								  	target = PREV
+								    type = annex_everything
+								}	
+							}			
+						}
+					}				
+				}
+
+				615 = {
+					owner =  {
+						ROOT = {
+							if = {
+								limit = {
+									NOT = { has_wargoal_against = PREV }
+								}
+								create_wargoal = {
+								  	target = PREV
+								    type = annex_everything
+								}
+							}					
+						}
+					}				
+				}
+
+				611 = {
+					owner =  {
+						ROOT = {
+							if = {
+								limit = {
+									NOT = { has_wargoal_against = PREV }
+								}
+								create_wargoal = {
+								  	target = PREV
+								    type = annex_everything
+								}	
+							}					
+						}
+					}				
+				}
+
+				328 = {
+					owner =  {
+						ROOT = {
+							if = {
+								limit = {
+									NOT = { has_wargoal_against = PREV }
+								}
+								create_wargoal = {
+								  	target = PREV
+								    type = annex_everything
+								}
+							}					
+						}
+					}				
+				}
+			}
+			custom_effect_tooltip = POR_expand_the_chinese_territories_tt
+
+			hidden_effect = {
+				random_country = {
+					limit = { controls_state = 592 }
+					ROOT = {
+						add_ai_strategy = {
+							type = prepare_for_war
+							id = PREV
+							value = 100
+						}
+					}
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_deal_with_the_japanese_threat
+
+		will_lead_to_war_with = JAP
+
+		select_effect = {
+			add_ai_strategy = {
+				type = prepare_for_war
+				id = JAP
+				value = 100
+			}
+		}
+		
+		available = {
+			JAP = {
+				exists = yes
+				NOT = { is_in_faction_with = ROOT }
+			}
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_the_fifth_empire }
+		prerequisite = { focus = POR_recover_the_east_indies }		
+		icon = GFX_focus_attack_japan
+		x = 1		
+		y = 1
+
+		relative_position_id = POR_the_fifth_empire
+		cost = 10
+		completion_reward = { 
+			create_wargoal = {
+				target = JAP
+				type = annex_everything
+				expire = 0
+			}
+
+			hidden_effect = {
+				add_ai_strategy = {
+					type = declare_war
+					id = JAP
+					value = 100
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_refuse_the_naval_blockade
+		available = {	
+			has_equipment = {
+			  convoy > 150
+			}
+			ENG = { has_war = yes}
+			NOT = {
+				is_in_faction_with = ENG
+			}
+		}
+
+		bypass = {	
+			ENG = {
+				OR = {	
+					exists = no
+					has_capitulated = yes
+					has_war_with = ROOT
+				}
+			}
+		}
+		prerequisite = { focus = POR_national_syndicalism focus = POR_the_return_of_duarte }
+		
+		icon = GFX_goal_generic_navy_anti_submarine
+		x = 3		
+		y = 1
+
+		relative_position_id = POR_national_syndicalism
+		cost = 10
+		completion_reward = { 
+			every_other_country = {
+				limit = {
+					has_war_with = ENG
+				}
+					 								
+				country_event = { 
+					id = lar_portugal_naval_blockade.1
+				}
+			}
+			ENG = {
+				country_event = { 
+					id = lar_portugal_naval_blockade.3
+				}
+				remove_opinion_modifier = {
+					target = POR
+					modifier = POR_anglo_portuguese_alliance
+				}
+			}
+			remove_opinion_modifier = {
+					target = ENG
+					modifier = POR_anglo_portuguese_alliance
+			}		
+		}
+	}
+
+	focus = {
+		id = POR_mapa_cor_de_rosa
+
+		select_effect = {
+			every_country = {
+				limit = { 
+					OR = {
+						controls_state = 770
+						controls_state = 545
+						controls_state = 771
+					}
+				}
+				ROOT = {
+					add_ai_strategy = {
+						type = prepare_for_war
+						id = PREV
+						value = 100
+					}
+				}
+			}
+		}
+
+		available = {			
+		}
+
+		bypass = {
+			AND = {
+				owns_state = 770
+				owns_state = 545
+				owns_state = 771
+			}
+		}
+		prerequisite = { focus = POR_refuse_the_naval_blockade }
+		icon = GFX_focus_por_the_pink_map
+		x = 0		
+		y = 1
+
+		relative_position_id = POR_refuse_the_naval_blockade
+		cost = 10
+		completion_reward = { 	
+			add_state_claim = 770 #Malawi
+			add_state_claim = 545 #Rhodesia
+			add_state_claim = 771 #Zambia
+
+			hidden_effect = {
+				random_country = {
+					limit = { 
+						OR = {
+							controls_state = 770
+							controls_state = 545
+							controls_state = 771
+						}
+					}
+					ROOT = {
+						add_ai_strategy = {
+							type = declare_war
+							id = PREV
+							value = 100
+						}
+					}
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_recover_the_east_indies
+
+		select_effect = {
+			random_country = {
+				limit = { controls_state = 336 }
+				ROOT = {
+					add_ai_strategy = {
+						type = prepare_for_war
+						id = PREV
+						value = 100
+					}
+				}
+			}
+			random_country = {
+				limit = { controls_state = 667 }
+				ROOT = {
+					add_ai_strategy = {
+						type = prepare_for_war
+						id = PREV
+						value = 100
+					}
+				}
+			}
+		}
+
+		available = {			
+		}
+
+		bypass = {
+			owns_state = 336
+			owns_state = 667
+		}
+		prerequisite = { focus = POR_mapa_cor_de_rosa }
+		icon = GFX_focus_RAJ_seek_help_from_germany
+		x = 0		
+		y = 1
+
+		relative_position_id = POR_mapa_cor_de_rosa
+		cost = 10
+		completion_reward = { 
+			add_state_claim = 336 # Singapore
+			add_state_claim = 667 # Lesser Sunda
+
+			hidden_effect = {
+				random_country = {
+					limit = { controls_state = 336 }
+					ROOT = {
+						add_ai_strategy = {
+							type = declare_war
+							id = PREV
+							value = 100
+						}
+					}
+				}
+				random_country = {
+					limit = { controls_state = 667 }
+					ROOT = {
+						add_ai_strategy = {
+							type = declare_war
+							id = PREV
+							value = 100
+						}
+					}
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_recover_brazil
+
+		will_lead_to_war_with = BRA
+
+		select_effect = {
+			random_country = {
+				limit = { controls_state = 500 }
+				ROOT = {
+					add_ai_strategy = {
+						type = prepare_for_war
+						id = PREV
+						value = 100
+					}
+				}
+			}	
+		}
+
+		available = {			
+		}
+
+		bypass = {
+			owns_state = 500
+		}
+		prerequisite = { focus = POR_mapa_cor_de_rosa }
+
+		mutually_exclusive = { focus = POR_the_kingdom_reunited }
+
+		icon = GFX_focus_por_recover_brazil
+		x = 1
+		y = 2
+
+		relative_position_id = POR_mapa_cor_de_rosa
+		cost = 10
+		completion_reward = { 	
+			add_state_claim = 500 #Rio
+
+			hidden_effect = {
+				random_country = {
+					limit = { controls_state = 500 }
+					ROOT = {
+						add_ai_strategy = {
+							type = declare_war
+							id = PREV
+							value = 100
+						}
+					}
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_a_royal_wedding
+		available = {			
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_estado_novo }
+
+		mutually_exclusive = { focus = POR_support_the_spanish_nationalists focus = POR_strict_neutrality_in_the_spanish_civil_war focus = POR_support_the_spanish_republic }
+
+		icon = GFX_focus_generic_royal_wedding
+		x = 13
+		y = 0
+
+		relative_position_id = POR_support_the_spanish_nationalists
+		cost = 10
+		search_filters = {FOCUS_FILTER_POLITICAL FOCUS_FILTER_INDUSTRY}
+		completion_reward = { 
+			hidden_effect = {
+				news_event = { id = lar_news.25 days = 3 random_days = 5 }
+			}	
+			add_political_power = 120
+			unlock_decision_tooltip = POR_stir_monarchist_sentiment_in_brazil
+			unlock_decision_tooltip = POR_stir_monarchist_sentiment_in_portugal
+			custom_effect_tooltip = available_political_advisor
+			show_ideas_tooltip = POR_joao_de_azevedo_coutinho
+			show_ideas_tooltip = POR_joao_francisco_de_barbosa_azevedo
+		}
+	}
+
+	focus = {
+		id = POR_the_return_of_duarte
+		available = {			
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_a_royal_wedding }
+		icon = GFX_focus_generic_monarchy_1
+		x = 0	
+		y = 2
+
+		relative_position_id = POR_a_royal_wedding
+		cost = 10
+		search_filters = {FOCUS_FILTER_POLITICAL}
+		completion_reward = { 	
+			set_party_name = { 
+			    ideology = neutrality
+			    long_name = POR_monarchy_party_long
+			    name = POR_monarchy_party
+			}
+
+			add_popularity = {
+			    ideology = neutrality
+			    popularity = -0.20
+			}
+
+			add_popularity = {
+			    ideology = democratic
+			    popularity = 0.10
+			}
+
+			add_popularity = {
+			    ideology = fascism
+			    popularity = 0.10
+			}
+
+			add_stability = -0.20
+		}
+	}
+
+	focus = {
+		id = POR_support_a_spanish_monarchy_in_the_war
+
+		available = {
+			SPR_scw_in_progress = yes
+			country_exists = SPB
+			NOT = { has_war_with = SPB }	
+		}
+
+		bypass = {
+			has_global_flag = scw_over
+		}
+
+		prerequisite = { focus = POR_the_return_of_duarte }
+		icon = GFX_focus_spa_supremacy_of_the_communion
+		x = 2
+		y = 1
+
+		relative_position_id = POR_the_return_of_duarte
+		cost = 10
+		completion_reward = { 	
+			SPB = {
+				add_opinion_modifier = {
+				    target = POR
+				    modifier = POR_helped_in_civil_war
+				}
+				add_manpower = 10000
+			}			
+			add_ideas = POR_volunteers_in_the_war_carlist
+			add_manpower = -10000
+			hidden_effect = {
+				add_equipment_to_stockpile = {
+					type = infantry_equipment
+					amount = 2000
+				}
+			}
+			send_equipment = {
+			    equipment = infantry_equipment
+			    amount = 2000
+			    target = SPB
+			}
+			set_rule = { can_send_volunteers = yes }
+		}
+	}
+
+	focus = {
+		id = POR_assist_the_requetes
+		available = {
+			SPR_scw_in_progress = yes
+			country_exists = SPB
+			NOT = { has_war_with = SPB }	
+		}
+
+		bypass = {
+			has_global_flag = scw_over
+		}
+		prerequisite = { focus = POR_support_a_spanish_monarchy_in_the_war }
+		icon = GFX_goal_generic_military_deal
+		x = 0
+		y = 1
+
+		relative_position_id = POR_support_a_spanish_monarchy_in_the_war
+		cost = 10
+		search_filters = {FOCUS_FILTER_RESEARCH}
+		completion_reward = {
+			add_tech_bonus = {
+				name = POR_assist_the_requetes
+			    bonus = 1.0
+			    uses = 1
+			    category = mountaineers_tech
+			}
+			add_tech_bonus = {
+				name = POR_assist_the_requetes
+			    bonus = 0.5
+			    uses = 1
+			    category = air_doctrine
+			}
+			add_tech_bonus = {
+				name = POR_assist_the_requetes
+			    bonus = 0.5
+			    uses = 1
+			    category = land_doctrine
+			}
+			army_experience = 15
+			air_experience = 15
+
+			hidden_effect = {
+				add_ai_strategy = {
+					type = befriend
+					id = SPB
+					value = 100
+				}
+				SPB = {
+					add_ai_strategy = {
+						type = befriend
+						id = ROOT
+						value = 100
+					}
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_join_the_carlist_fight
+
+		select_effect = {
+			if = {
+				limit = {
+					country_exists = SPA
+					is_neighbor_of = SPA
+				}
+				add_ai_strategy = {
+					type = prepare_for_war
+					id = SPA
+					value = 100
+				}
+			}
+			if = {
+				limit = {
+					country_exists = SPD
+					is_neighbor_of = SPD
+				}
+				add_ai_strategy = {
+					type = prepare_for_war
+					id = SPD
+					value = 100
+				}
+			}
+			if = {
+				limit = {
+					country_exists = SPC
+					is_neighbor_of = SPC
+				}
+				add_ai_strategy = {
+					type = prepare_for_war
+					id = SPC
+					value = 100
+				}
+			}
+		}
+
+		available = {
+			has_civil_war = no
+			SPR_scw_in_progress = yes
+			country_exists = SPB
+			NOT = { has_war_with = SPB }
+			is_puppet = no
+		}
+
+		bypass = {
+			has_global_flag = scw_over
+		}
+		prerequisite = { focus = POR_assist_the_requetes }
+		icon = GFX_focus_spa_no_compromise_on_carlist_ideals
+		x = 0
+		y = 1
+
+		relative_position_id = POR_assist_the_requetes
+		cost = 10
+		completion_reward = { 	
+			unlock_decision_tooltip = POR_fight_alongside_the_carlists
+			if = { 
+				limit = { country_exists = SPA }
+				SPA = {
+					country_event = { id = lar_portugal_spanish_civil_war.3 }
+				}
+			}
+			if = { 
+				limit = { country_exists = SPD }
+				SPD = {
+					country_event = { id = lar_portugal_spanish_civil_war.3 }
+				}
+			}
+			if = { 
+				limit = { country_exists = SPC }
+				SPC = {
+					country_event = { id = lar_portugal_spanish_civil_war.3 }
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_the_royal_iberian_alliance
+		available = {
+			is_in_faction = no
+			has_country_leader = { name = "Dom Duarte Nuno" }
+			has_global_flag = scw_over
+			has_completed_focus = POR_restoration_of_the_monarchy
+			country_exists = SPB
+			NOT = { has_war_with = SPB }
+			SPB = { has_completed_focus = SPA_restore_the_monarchy }
+		}
+
+		ai_will_do = {
+			factor = 1
+			modifier = {
+				factor = 100
+				has_idea = POR_volunteers_in_the_war_carlist
+			}
+			modifier = {
+				factor = 2
+				has_opinion = {
+					target = SPB
+					value > 30
+				}
+			}
+		}
+
+		bypass = {
+		}
+		prerequisite = { focus = POR_join_the_carlist_fight }
+		mutually_exclusive = { focus = POR_remember_olivenca }
+		icon = GFX_goal_tfv_strengthen_commonwealth_ties
+		x = 0
+		y = 1
+
+		relative_position_id = POR_join_the_carlist_fight
+		cost = 10
+		completion_reward = {
+			SPB = { 
+				country_event = { id = lar_portugal_royal_iberian_alliance.1 hours = 6 }
+			}
+		}
+	}
+
+	focus = {
+		id = POR_promote_the_monarchist_cause_in_portugal
+		available = {			
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_the_return_of_duarte }
+		icon = GFX_focus_generic_monarchy_2
+		x = 0
+		y = 1
+
+		relative_position_id = POR_the_return_of_duarte
+		cost = 10
+		search_filters = {FOCUS_FILTER_POLITICAL}
+		completion_reward = { 	
+			add_timed_idea = {
+			    idea = POR_monarchists_on_the_rise2
+			    days = 730
+			}
+		}
+	}
+
+	focus = {
+		id = POR_monarchist_uprising_in_brazil
+		available = {
+		}
+
+		bypass = {
+			NOT = { country_exists = BRA }
+			BRA = { has_capitulated = yes }
+		}
+		prerequisite = { focus = POR_the_return_of_duarte }
+		icon = GFX_focus_por_reclaim_crown_jewel
+		x = -2
+		y = 1
+
+		relative_position_id = POR_the_return_of_duarte
+		cost = 10
+		completion_reward = {
+			BRA = {
+				country_event = lar_portugal_promote_monarchist_cause.7
+				effect_tooltip = {
+					add_timed_idea = {
+					    idea = POR_monarchists_on_the_rise
+					    days = 730
+					}
+					set_party_name = { 
+					    ideology = neutrality
+					    long_name = BRA_monarchy_party_long
+					    name = BRA_monarchy_party
+					}
+					set_party_name = { 
+					    ideology = fascism
+					    long_name = BRA_antimonarchist_coalition_long
+					    name = BRA_antimonarchist_coalition
+					}
+					if = {
+						limit = {
+							OR = {
+								has_government = neutrality
+								has_government = democratic
+								has_government = communism
+							} 
+						}
+						set_politics = {
+							ruling_party = fascism
+						}
+					}
+					set_popularities = {
+						democratic = 0
+						neutrality = 20
+						fascism = 80
+						communism = 0
+					}
+					hidden_effect = {
+						retire_country_leader = yes
+					}
+					create_country_leader = {
+						name = "Getúlio Vargas"
+						desc = "POLITICS_GETÚLIO_VARGAS_DESC"
+						picture = "gfx/leaders/BRA/Portrait_Brazil_Getulio_Vargas.dds"
+						expire = "1954.8.24"
+						ideology = fascism_ideology
+						traits = {
+							anti_communist
+						}					
+					}
+					create_country_leader = {
+						name = "Arlindo Veiga dos Santos"
+						desc = "POLITICS_ARLINDO_VEIGA_DOS_SANTOS_DESC"
+						picture = "gfx/leaders/BRA/portrait_bra_arlindo_veiga_dos_santos.dds"
+						expire = "1954.8.24"
+						ideology = despotism
+						traits = {
+							staunch_monarchist
+						}					
+					}
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_the_empire_of_brazil
+
+		select_effect = {
+			if = {
+				limit = {
+					has_war = no
+				}
+				add_ai_strategy = {
+					type = prepare_for_war
+					id = BRA
+					value = 100
+				}
+			}
+		}
+
+		available = {
+			is_puppet = no
+		}
+
+		bypass = {
+			NOT = { country_exists = BRA }
+			BRA = { has_capitulated = yes }	
+		}
+		prerequisite = { focus = POR_monarchist_uprising_in_brazil }
+		icon = GFX_focus_generic_home_defense
+		x = 0		
+		y = 1
+
+		relative_position_id = POR_monarchist_uprising_in_brazil
+		cost = 10
+		completion_reward = {
+			if = {
+				limit = {
+					BRA = {
+						OR = {
+							has_country_flag = POR_brazil_supports_fascist_coalition_flag
+							AND = {
+								NOT = { has_government = neutrality }
+								OR = {
+									has_stability < 0.5
+									neutrality < 0.7
+								}
+							}
+						}
+					}
+				}
+				BRA = { country_event = lar_portugal_promote_monarchist_cause.3 }
+			}
+			else = {
+				BRA = { country_event = lar_portugal_promote_monarchist_cause.4 }
+			}
+			custom_effect_tooltip = POR_the_empire_of_brazil_potential_civil_war_tt
+
+			hidden_effect = {
+				every_country = {
+					limit = {
+						original_tag = BRA
+						has_government = neutrality
+					}
+					add_ai_strategy = {
+						type = befriend
+						id = ROOT
+						value = 100
+					}
+					ROOT = {
+						add_ai_strategy = {
+							type = befriend
+							id = PREV
+							value = 100
+						}
+					}
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_restoration_of_the_monarchy
+		available = {	
+			has_government = neutrality
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_promote_the_monarchist_cause_in_portugal }
+		icon = GFX_focus_rom_royal_dictatorship
+		x = 0		
+		y = 1
+
+		relative_position_id = POR_promote_the_monarchist_cause_in_portugal
+		cost = 10
+		search_filters = {FOCUS_FILTER_POLITICAL FOCUS_FILTER_INDUSTRY
+		FOCUS_FILTER_STABILITY}
+		completion_reward = {
+			remove_ideas = POR_estado_novo
+			swap_ideas = {
+				remove_idea = POR_unstable_republic
+				add_idea = POR_unstable_monarchy
+			}
+			if = { #Low Stability triggers a Civil War
+				limit = {
+					has_stability < 0.4
+				}
+				set_temp_variable = { POR_monarchist_cw_opposition = party_popularity@fascism }
+				add_to_temp_variable = { POR_monarchist_cw_opposition = party_popularity@communism }
+				add_to_temp_variable = { POR_monarchist_cw_opposition = party_popularity@democratic }
+				start_civil_war = {	
+					ideology = fascism
+					size = POR_monarchist_cw_opposition
+					capital = 180
+					states = { 181 }
+				}
+			}
+			else = {
+				add_stability = -0.1
+			}
+			set_country_flag = KOP_kingdom_of_portugal_flag
+			set_cosmetic_tag = KOP_kingdom_portugal
+			create_country_leader = {
+				name = "Dom Duarte Nuno"
+				desc = "POLITICS_DOM_DUARTE_NUNO_DESC"
+				picture = "gfx/leaders/POR/portrait_por_duarte_nuno.dds"
+				expire = "1976.12.24"
+				ideology = despotism
+				traits = { 
+					constitutional_monarch_minor
+				}
+			}
+			custom_effect_tooltip = POR_potential_civil_war_low_requirement_tt
+		}
+	}
+
+	focus = {
+		id = POR_the_kingdom_reunited
+		available = {
+			has_government = neutrality
+			OR = {
+				AND = {
+					country_exists = BRA
+					BRA = {
+						has_government = neutrality
+						has_civil_war = no
+						NOT = { has_war_with = ROOT }
+					}
+					NOT = {
+						any_enemy_country = {
+							is_in_faction_with = BRA
+						}
+					}
+				}
+				AND = {
+					NOT = { country_exists = BRA }
+					owns_state = 500
+				}
+			}
+		}
+
+		bypass = {
+		}
+		prerequisite = { focus = POR_restoration_of_the_monarchy }
+		prerequisite = { focus = POR_the_empire_of_brazil }
+
+		mutually_exclusive = { focus = POR_recover_brazil }
+
+		icon = GFX_focus_por_the_kingdom_reunited
+		x = -1
+		y = 2
+
+		relative_position_id = POR_the_empire_of_brazil
+		cost = 10
+		search_filters = {FOCUS_FILTER_POLITICAL FOCUS_FILTER_STABILITY FOCUS_FILTER_INDUSTRY FOCUS_FILTER_MANPOWER FOCUS_FILTER_WAR_SUPPORT FOCUS_FILTER_ANNEXATION}
+		completion_reward = {
+			remove_ideas = POR_unstable_monarchy
+			add_ideas = POR_the_portuguese_empire
+			if = {
+				limit = {
+					country_exists = BRA
+				}
+				BRA = {
+					country_event = { id = lar_portugal_promote_monarchist_cause.2 hours = 6 }
+				}
+			}
+			set_rule = { can_create_factions = yes }
+		}		
+	}
+
+	focus = {
+		id = POR_remember_olivenca
+		available = {
+		}
+
+		ai_will_do = {
+			factor = 1
+			modifier = {
+				factor = 10
+				has_opinion = {
+					target = SPB
+					value < 0
+				}
+			}
+			modifier = {
+				factor = 2
+				has_government = neutrality
+				SPB = { NOT = { has_government = neutrality } }
+			}
+		}
+
+		bypass = {
+			owns_state = 170
+			owns_state = 169
+		}
+		prerequisite = { focus = POR_restoration_of_the_monarchy }
+		mutually_exclusive = { focus = POR_the_royal_iberian_alliance }
+		icon = GFX_focus_por_remember_olivenca
+		x = 0
+		y = 2
+
+		relative_position_id = POR_restoration_of_the_monarchy
+		cost = 10
+		completion_reward = { 	
+			add_state_claim = 170
+			add_state_claim = 169
+
+			hidden_effect = {
+				random_country = {
+					limit = { controls_state = 170 }
+					ROOT = {
+						add_ai_strategy = {
+							type = prepare_for_war
+							id = PREV
+							value = 100
+						}
+					}
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_deal_with_fascism
+
+		select_effect = {
+			random_country = {
+				limit = {
+					has_government = fascism
+					NOT = { is_in_faction_with = ROOT }
+					OR = {
+						is_major = yes
+						is_neighbor_of = ROOT
+					}
+				}
+				ROOT = {
+					add_ai_strategy = {
+						type = prepare_for_war
+						id = PREV
+						value = 100
+					}
+				}
+			}	
+		}
+
+		available = {
+			any_country = {
+				has_government = fascism
+				NOT = { is_in_faction_with = ROOT }
+				OR = {
+					is_major = yes
+					is_neighbor_of = ROOT
+				}
+			}
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_remember_olivenca focus = POR_the_royal_iberian_alliance }
+		icon = GFX_focus_attack_germany
+		x = 1
+		y = 1
+
+		relative_position_id = POR_remember_olivenca
+		cost = 10
+		completion_reward = { 	
+			hidden_effect = {
+				every_country = {
+					limit = {
+						has_government = fascism
+						NOT = { is_in_faction_with = ROOT }
+						OR = {
+							is_major = yes
+							is_neighbor_of = ROOT
+						}
+					}
+					ROOT = {
+						create_wargoal = {
+							target = PREV
+							type = annex_everything
+							expire = 0
+						}
+					}
+				}
+			}
+			custom_effect_tooltip = POR_deal_with_fascism_tt
+			every_country = { #TOOLTIP Support
+				limit = {
+					has_government = fascism
+					NOT = { is_in_faction_with = ROOT }
+					OR = {
+						is_major = yes
+						is_neighbor_of = ROOT
+					}
+				}
+			}
+
+			hidden_effect = {
+				random_country = {
+					limit = {
+						has_government = fascism
+						NOT = { is_in_faction_with = ROOT }
+						OR = {
+							is_major = yes
+							is_neighbor_of = ROOT
+						}
+					}
+					ROOT = {
+						add_ai_strategy = {
+							type = declare_war
+							id = PREV
+							value = 100
+						}
+					}
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_latin_america
+
+		will_lead_to_war_with = PAR
+		will_lead_to_war_with = URG
+		will_lead_to_war_with = ARG
+
+		select_effect = {
+			random_country = {
+				limit = { controls_state = 300 }
+				ROOT = {
+					add_ai_strategy = {
+						type = prepare_for_war
+						id = PREV
+						value = 100
+					}
+				}
+			}
+			random_country = {
+				limit = { controls_state = 301 }
+				ROOT = {
+					add_ai_strategy = {
+						type = prepare_for_war
+						id = PREV
+						value = 100
+					}
+				}
+			}
+			random_country = {
+				limit = { controls_state = 510 }
+				ROOT = {
+					add_ai_strategy = {
+						type = prepare_for_war
+						id = PREV
+						value = 100
+					}
+				}
+			}
+		}
+
+		available = {
+		}
+
+		bypass = {
+			owns_state = 300
+			owns_state = 301
+			owns_state = 510
+		}
+		prerequisite = { focus = POR_the_kingdom_reunited focus = POR_recover_brazil }
+
+		icon = GFX_focus_por_recover_latin_america
+		x = -1
+		y = 1
+
+		relative_position_id = POR_the_kingdom_reunited
+		cost = 10
+		completion_reward = { 
+			add_state_claim = 300
+			add_state_claim = 301
+			add_state_claim = 510
+
+			hidden_effect = {
+				random_country = {
+					limit = { controls_state = 300 }
+					ROOT = {
+						add_ai_strategy = {
+							type = declare_war
+							id = PREV
+							value = 100
+						}
+					}
+				}
+				random_country = {
+					limit = { controls_state = 301 }
+					ROOT = {
+						add_ai_strategy = {
+							type = declare_war
+							id = PREV
+							value = 100
+						}
+					}
+				}
+				random_country = {
+					limit = { controls_state = 510 }
+					ROOT = {
+						add_ai_strategy = {
+							type = declare_war
+							id = PREV
+							value = 100
+						}
+					}
+				}
+			}
+		}
+	}
+
+	focus = {
+		id = POR_the_communist_threat
+
+		select_effect = {
+			every_country = {
+				limit = {
+					has_government = communism
+					NOT = { is_in_faction_with = ROOT }
+					OR = {
+						is_major = yes
+						is_neighbor_of = ROOT
+					}
+				}
+				ROOT = {
+					add_ai_strategy = {
+						type = prepare_for_war
+						id = PREV
+						value = 100
+					}
+				}
+			}
+		}
+
+		available = {
+			any_country = {
+				has_government = communism
+				NOT = { is_in_faction_with = ROOT }
+				OR = {
+					is_major = yes
+					is_neighbor_of = ROOT
+				}
+			}
+		}
+
+		bypass = {		
+		}
+		prerequisite = { focus = POR_latin_america focus = POR_proudly_alone }
+
+		icon = GFX_focus_ger_great_red_menace
+		x = -8
+		y = 1
+
+		relative_position_id = POR_latin_america
+		cost = 10
+		completion_reward = {
+			hidden_effect = {
+				every_country = {
+					limit = {
+						has_government = communism
+						NOT = { is_in_faction_with = ROOT }
+						OR = {
+							is_major = yes
+							is_neighbor_of = ROOT
+						}
+					}
+					if = {
+						limit = {
+							ROOT = { has_cosmetic_tag = KPB_kingdom_portugal_and_brazil } #Non-Aligned Duarte Nuno (Monarchist)
+						}
+						ROOT = {
+							create_wargoal = {
+								target = PREV
+								type = puppet_wargoal_focus
+								expire = 0
+							}
+						}
+					}
+					else_if = {
+						limit = {
+							ROOT = { has_government = neutrality }  #Non-Aligned Salazar (Even in Monarchist branch if Duarte Nuno is not ruler yet)
+						}
+							ROOT = {
+								create_wargoal = {
+									target = PREV
+									type = topple_government
+									expire = 0
+								}
+							}
+					}
+					else = { #Fascist Preto
+						ROOT = {
+							create_wargoal = {
+								target = PREV
+								type = annex_everything
+								expire = 0
+							}
+						}
+					}
+				}
+			}
+			custom_effect_tooltip = POR_the_communist_threat_tt
+			every_country = {
+				limit = {
+					has_government = communism
+					NOT = { is_in_faction_with = ROOT }
+					OR = {
+						is_major = yes
+						is_neighbor_of = ROOT
+					}
+				}
+			}
+
+			hidden_effect = {
+				every_country = {
+					limit = {
+						has_government = communism
+						NOT = { is_in_faction_with = ROOT }
+						OR = {
+							is_major = yes
+							is_neighbor_of = ROOT
+						}
+					}
+					ROOT = {
+						add_ai_strategy = {
+							type = declare_war
+							id = PREV
+							value = 100
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/common/national_focus/portugal.txt
+++ b/common/national_focus/portugal.txt
@@ -4789,9 +4789,15 @@ focus_tree = {
 	focus = {
 		id = POR_honor_anglo_portuguese_alliance
 		available = {
-			is_in_faction = no
-			has_war = no
-			ENG = { 
+			OR = {
+				AND = {
+					is_in_faction = no
+					has_war = no
+
+				}
+				is_in_faction_with = ENG
+			}
+			ENG = {
 				exists = yes
 				NOT = {
 					has_war_with = ROOT 
@@ -4830,11 +4836,15 @@ focus_tree = {
 						is_faction_leader = yes
 						has_government = democratic
 						NOT = { has_war_with = ROOT }
+						NOT = { is_in_faction_with = ROOT }
 					}
 				}
 				ENG = { country_event = { id = generic.2 hours = 4 } }
 			}
-			else = {
+			else_if = {
+				limit = {
+					is_in_faction = no
+				}
 				get_best_alliance_match_democratic_effect = yes
 				var:best_leader = {
 					country_event = { id = generic.2 hours = 4 }

--- a/common/national_focus/portugal.txt
+++ b/common/national_focus/portugal.txt
@@ -2411,6 +2411,13 @@ focus_tree = {
 		x = 9
 		y = 0
 
+		allow_branch = {
+			has_game_rule = {
+				rule = IHMP_HISTORY
+				option = ALLOWED
+			}
+		}
+
 		relative_position_id = POR_army_reorganization
 		cost = 10
 		search_filters = {FOCUS_FILTER_POLITICAL}
@@ -4179,6 +4186,10 @@ focus_tree = {
 		x = 2		
 		y = 1
 
+		allow_branch = {
+			always = yes
+		}
+
 		relative_position_id = POR_join_the_allies
 		cost = 10
 		search_filters = {FOCUS_FILTER_RESEARCH}
@@ -4961,6 +4972,13 @@ focus_tree = {
 		x = -1
 		y = 1
 
+		allow_branch = {
+			has_game_rule = {
+				rule = IHMP_HISTORY
+				option = ALLOWED
+			}
+		}
+
 		relative_position_id = POR_proudly_alone
 		cost = 10
 		completion_reward = { 
@@ -4994,6 +5012,13 @@ focus_tree = {
 		icon = GFX_focus_generic_strike_at_democracy2
 		x = 8	
 		y = 0
+
+		allow_branch = {
+			has_game_rule = {
+				rule = IHMP_HISTORY
+				option = ALLOWED
+			}
+		}
 
 		relative_position_id = POR_observation_mission
 		cost = 10
@@ -5703,6 +5728,13 @@ focus_tree = {
 		icon = GFX_focus_generic_royal_wedding
 		x = 13
 		y = 0
+
+		allow_branch = {
+			has_game_rule = {
+				rule = IHMP_HISTORY
+				option = ALLOWED
+			}
+		}
 
 		relative_position_id = POR_support_the_spanish_nationalists
 		cost = 10


### PR DESCRIPTION
[F] Removed ahistorical branches Portuguese Focus branches on historical game_rule
[F] Made Honor Anglo-Portuguese Alliance focus pickable if UK already invited Portugal in Allies, this allows Portugal to remove the Unstable Republic modifier and join the Commonwealth Research group with the focus after
[F] Fixed some small AI scripting errors, for picking research (they didn't research concentrated industry) and PP spending (they also swapped between partial mob and war eco over and over again)
[A] Made Portugal AI pick the honor anglo alliance focus, if they are in a faction with UK